### PR TITLE
Add Docker Compose support for local app + agent runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ All visuals are rendered in sandboxed iframes with automatic light/dark theming,
 pnpm install
 
 # Add your OpenAI API key
-echo 'OPENAI_API_KEY=your-key' > apps/agent/.env
+echo 'OPENAI_API_KEY=your-key' > .env
 
 # Start all services
 pnpm dev
@@ -33,10 +33,9 @@ pnpm dev
 
 ## Run with Docker Compose
 
-```bash
-# Add your OpenAI API key at the repo root
-echo 'OPENAI_API_KEY=your-key' > .env
+With the repo-root `.env` file from Quick Start in place:
 
+```bash
 # Build and start the frontend + agent
 docker compose up --build
 ```

--- a/README.md
+++ b/README.md
@@ -28,14 +28,32 @@ echo 'OPENAI_API_KEY=your-key' > apps/agent/.env
 pnpm dev
 ```
 
-- **App**: http://localhost:3000
-- **Agent**: http://localhost:8123
+- **App**: [http://localhost:3000](http://localhost:3000)
+- **Agent**: [http://localhost:8123](http://localhost:8123)
+
+## Run with Docker Compose
+
+```bash
+# Add your OpenAI API key at the repo root
+echo 'OPENAI_API_KEY=your-key' > .env
+
+# Build and start the frontend + agent
+docker compose up --build
+```
+
+- **App**: [http://localhost:3000](http://localhost:3000)
+- **Agent**: [http://localhost:8123](http://localhost:8123)
+
+The Compose setup starts two services:
+
+- `app` — Next.js frontend, configured to reach the agent at `http://agent:8123`
+- `agent` — LangGraph Python agent, using the root `.env` file mounted read-only at `/workspace/.env`
 
 ## Architecture
 
 Turborepo monorepo with two apps:
 
-```
+```text
 apps/
 ├── app/       Next.js 16 frontend (CopilotKit v2, React 19, Tailwind 4)
 └── agent/     LangGraph Python agent (GPT-5.4, CopilotKit middleware)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+services:
+  agent:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.agent
+    env_file:
+      - .env
+    volumes:
+      - ./.env:/workspace/.env:ro
+    ports:
+      - "8123:8123"
+
+  app:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.app
+    environment:
+      LANGGRAPH_DEPLOYMENT_URL: http://agent:8123
+    depends_on:
+      - agent
+    ports:
+      - "3000:3000"

--- a/docker/Dockerfile.agent
+++ b/docker/Dockerfile.agent
@@ -1,0 +1,25 @@
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /workspace/apps/agent
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends nodejs npm build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip install --no-cache-dir uv \
+    && npm install -g @langchain/langgraph-cli@1.1.12
+
+COPY apps/agent/package.json ./package.json
+COPY apps/agent/pyproject.toml ./pyproject.toml
+COPY apps/agent/uv.lock ./uv.lock
+
+RUN uv sync --frozen
+
+COPY apps/agent/ ./
+
+EXPOSE 8123
+
+CMD ["langgraphjs", "dev", "--host", "0.0.0.0", "--port", "8123", "--no-browser"]

--- a/docker/Dockerfile.agent
+++ b/docker/Dockerfile.agent
@@ -22,4 +22,4 @@ COPY apps/agent/ ./
 
 EXPOSE 8123
 
-CMD ["langgraphjs", "dev", "--host", "0.0.0.0", "--port", "8123", "--no-browser"]
+CMD ["npx", "@langchain/langgraph-cli", "dev", "--host", "0.0.0.0", "--port", "8123", "--no-browser"]


### PR DESCRIPTION
## Summary

Adds a Docker Compose setup for running the app and agent locally in containers, and updates the README to document the Docker workflow.

## Changes

- add docker-compose.yml to run `app` and `agent` together
- add Dockerfile.agent for the LangGraph agent
- update README.md with Docker instructions
- align environment setup to use the repo-root .env

## Why

This makes the project easier to run locally without starting each service manually.