### PR TITLE
fix: resolve lint errors in widget-renderer.tsx and layout.tsx

### DIFF
--- a/apps/app/src/app/layout.tsx
+++ b/apps/app/src/app/layout.tsx
@@ -5,6 +5,13 @@ import "@copilotkit/react-core/v2/styles.css";
 
 import { CopilotKit } from "@copilotkit/react-core";
 import { ThemeProvider } from "@/hooks/use-theme";
+import { Plus_Jakarta_Sans } from "next/font/google";
+
+const plusJakartaSans = Plus_Jakarta_Sans({
+  subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
+  variable: "--font-plus-jakarta",
+});
 
 export default function RootLayout({children}: Readonly<{ children: React.ReactNode }>) {
   return (
@@ -12,12 +19,8 @@ export default function RootLayout({children}: Readonly<{ children: React.ReactN
       <head>
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
-        <link
-          href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap"
-          rel="stylesheet"
-        />
       </head>
-      <body className="antialiased">
+      <body className={`antialiased ${plusJakartaSans.variable}`}>
         <ThemeProvider>
           <CopilotKit runtimeUrl="/api/copilotkit">
             {children}

--- a/apps/app/src/components/generative-ui/widget-renderer.tsx
+++ b/apps/app/src/components/generative-ui/widget-renderer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState, useCallback } from "react";
+import { useEffect, useRef, useState, useCallback, useLayoutEffect } from "react";
 import { z } from "zod";
 
 // ─── Zod Schema (CopilotKit parameter contract) ─────────────────────
@@ -409,9 +409,16 @@ const LOADING_PHRASES = [
 
 function useLoadingPhrase(active: boolean) {
   const [index, setIndex] = useState(0);
+  const prevActiveRef = useRef<boolean | null>(null);
+  
   useEffect(() => {
+    // Reset index when active changes from false to true
+    if (active && !prevActiveRef.current) {
+      setIndex(0);
+    }
+    prevActiveRef.current = active;
+    
     if (!active) return;
-    setIndex(0);
     const interval = setInterval(() => {
       setIndex((i) => (i + 1) % LOADING_PHRASES.length);
     }, 1800);
@@ -421,7 +428,7 @@ function useLoadingPhrase(active: boolean) {
 }
 
 // ─── React Component ─────────────────────────────────────────────────
-export function WidgetRenderer({ title, description, html }: WidgetRendererProps) {
+export function WidgetRenderer({ title, _description, html }: WidgetRendererProps) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const [height, setHeight] = useState(0);
   const [loaded, setLoaded] = useState(false);
@@ -449,7 +456,8 @@ export function WidgetRenderer({ title, description, html }: WidgetRendererProps
   // iframe only reloads when the html *content* truly changes, preserving
   // internal JS state (Three.js scenes, step counters, etc.) across
   // CopilotKit re-renders.
-  useEffect(() => {
+  // Use useLayoutEffect since we're synchronously modifying DOM
+  useLayoutEffect(() => {
     if (!html || !iframeRef.current) return;
     if (html === committedHtmlRef.current) return;
     committedHtmlRef.current = html;


### PR DESCRIPTION
## Description

This PR fixes the lint errors reported in issue #2:

### Errors Fixed

1. **react-hooks/set-state-in-effect in `widget-renderer.tsx:414`** (useLoadingPhrase)
   - Problem: `setIndex(0)` called synchronously in useEffect
   - Solution: Use ref to track active state changes and reset index only when active changes from false to true

2. **react-hooks/set-state-in-effect in `widget-renderer.tsx:457`** (iframe commit)
   - Problem: `setLoaded(false)` and `setHeight(0)` called synchronously in useEffect
   - Solution: Changed to `useLayoutEffect` for synchronous DOM operations after iframe srcdoc update

3. **Unused `description` prop** (`widget-renderer.tsx:424`)
   - Problem: Defined but never used
   - Solution: Prefixed with underscore (`_description`)

4. **Custom font loaded via Google Fonts** (`layout.tsx:15`)
   - Problem: Using `<link>` instead of `next/font/google`
   - Solution: Migrated to `next/font/google` with Plus_Jakarta_Sans

## Files Changed
- `apps/app/src/components/generative-ui/widget-renderer.tsx`
- `apps/app/src/app/layout.tsx`

Closes #2