### PR TITLE
fix: prevent broken script execution in widget iframe

### DIFF
--- a/apps/app/src/components/generative-ui/widget-renderer.tsx
+++ b/apps/app/src/components/generative-ui/widget-renderer.tsx
@@ -430,7 +430,7 @@ window.addEventListener('message', function(e) {
             newScript.textContent = scriptInfo.text;
           }
           content.appendChild(newScript);
-        } catch(e) {}
+        } catch(e) { console.warn('[widget] script exec failed:', e); }
       });
     }
     reportHeight();


### PR DESCRIPTION
Closes #44

## Summary

- Fix Idiomorph.morph receiving an HTML string instead of a DOM node, causing incorrect diffing
- Defer script execution until all `<script>` tags are fully closed — prevents broken fragments from mid-stream content from executing and blocking subsequent scripts
- Sanitize base64 hashes used in `data-exec-*` attribute names (`=`, `+`, `/` are invalid in HTML attributes)
- Skip empty/whitespace-only scripts extracted during streaming
- Wrap individual script executions in try/catch so one failure doesn't abort the loop

## Problem

Interactive widgets (BFS/DFS graph visualizations, 3D animations) failed to render because:

1. `btoa()` output contains `=`, `+`, `/` which are invalid in HTML attribute names — `setAttribute('data-exec-Cg==')` throws `InvalidCharacterError`, aborting the entire script execution loop
2. During streaming, incomplete `<script>` tags produce broken code fragments (e.g. `\n  const`) that fail on execution
3. No error isolation — a single script failure killed the entire `forEach` loop, preventing later valid scripts from running

## Test plan

- [x] BFS/DFS node graph: nodes render, Play/Next Step/Reset buttons work
- [x] 3D sphere animation: renders correctly
- [x] No `InvalidCharacterError` or `setAttribute` errors in console
- [ ] Non-interactive widgets still render correctly (charts, diagrams)