### PR TITLE
fix: add visualization quality guidance to agent prompt

### DIFF
--- a/apps/agent/main.py
+++ b/apps/agent/main.py
@@ -53,6 +53,20 @@ agent = create_deep_agent(
         - Pre-styled form elements (buttons, inputs, sliders look native automatically)
         - Pre-built SVG CSS classes for color ramps (.c-purple, .c-teal, .c-blue, etc.)
 
+        ## Visualization Quality Standards
+
+        The iframe has an import map with these ES module libraries — use `<script type="module">` and bare import specifiers:
+        - `three` — 3D graphics. `import * as THREE from "three"`. Also `three/examples/jsm/controls/OrbitControls.js` for camera controls.
+        - `gsap` — animation. `import gsap from "gsap"`.
+        - `d3` — data visualization and force layouts. `import * as d3 from "d3"`.
+        - `chart.js/auto` — charts (but prefer the built-in `barChart`/`pieChart` components for simple charts).
+
+        **3D content**: ALWAYS use Three.js with proper WebGL rendering. Use real geometry, PBR materials (MeshStandardMaterial/MeshPhysicalMaterial), multiple light sources, and OrbitControls for interactivity. NEVER fake 3D with CSS transforms, CSS perspective, or Canvas 2D manual projection — these look broken and unprofessional.
+
+        **Quality bar**: Every visualization should look polished and portfolio-ready. Use smooth animations, proper lighting (ambient + directional at minimum), responsive canvas sizing (`window.addEventListener('resize', ...)`), and antialiasing (`antialias: true`). No proof-of-concept quality.
+
+        **Critical**: `<script type="module">` is REQUIRED when using import map libraries. Regular `<script>` tags cannot use `import` statements.
+
         ## UI Templates
 
         Users can save generated UIs as reusable templates and apply them later.


### PR DESCRIPTION
## Summary

- Add "Visualization Quality Standards" section to the agent system prompt
- Documents available import map libraries (Three.js, GSAP, D3, Chart.js) with correct import syntax
- Mandates Three.js for 3D content — explicitly prohibits CSS 3D faking and Canvas 2D projection
- Sets quality bar: polished, portfolio-ready output with proper lighting, antialiasing, responsive sizing
- Requires `<script type="module">` when using import map libraries

## Context

Generated visualizations have degraded in quality (see #58). The model was producing broken 3D content using CSS `transform-style: preserve-3d` hacks or Canvas 2D manual projection instead of Three.js, which is available via the import map. The system prompt had no guidance about available libraries or quality expectations.

## Test plan

- [ ] Deploy updated agent and test "sphere icosahedron morph" prompt — should use Three.js WebGL
- [ ] Test other 3D prompts (solar system, neural network) — verify Three.js usage
- [ ] Test non-3D prompts (diagrams, charts) — verify no regression
- [ ] Verify `<script type="module">` is used in generated HTML

Closes #58