### PR TITLE
feat: add interactive notebook app for OpenGenerativeUI demos

### DIFF
--- a/apps/notebook/eslint.config.mjs
+++ b/apps/notebook/eslint.config.mjs
@@ -1,0 +1,18 @@
+import nextCoreWebVitals from "eslint-config-next/core-web-vitals";
+import nextTypescript from "eslint-config-next/typescript";
+
+const eslintConfig = [
+  ...nextCoreWebVitals,
+  ...nextTypescript,
+  {
+    ignores: [
+      "node_modules/**",
+      ".next/**",
+      "out/**",
+      "build/**",
+      "next-env.d.ts",
+    ],
+  },
+];
+
+export default eslintConfig;

--- a/apps/notebook/next.config.ts
+++ b/apps/notebook/next.config.ts
@@ -1,0 +1,5 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {};
+
+export default nextConfig;

--- a/apps/notebook/package.json
+++ b/apps/notebook/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@repo/notebook",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev --turbopack --port 3001",
+    "build": "next build",
+    "start": "next start",
+    "lint": "eslint ."
+  },
+  "dependencies": {
+    "next": "16.1.6",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
+    "react-markdown": "^9.0.3",
+    "remark-gfm": "^4.0.0",
+    "@codesandbox/sandpack-react": "^2.19.0",
+    "shiki": "^3.2.0"
+  },
+  "devDependencies": {
+    "@eslint/eslintrc": "^3",
+    "@tailwindcss/postcss": "^4",
+    "@types/node": "^20",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "eslint": "^9",
+    "eslint-config-next": "16.1.6",
+    "tailwindcss": "^4",
+    "typescript": "^5"
+  }
+}

--- a/apps/notebook/package.json
+++ b/apps/notebook/package.json
@@ -15,7 +15,8 @@
     "react-markdown": "^9.0.3",
     "remark-gfm": "^4.0.0",
     "@codesandbox/sandpack-react": "^2.19.0",
-    "shiki": "^3.2.0"
+    "shiki": "^3.2.0",
+    "mermaid": "^11.4.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/apps/notebook/postcss.config.mjs
+++ b/apps/notebook/postcss.config.mjs
@@ -1,0 +1,5 @@
+const config = {
+  plugins: ["@tailwindcss/postcss"],
+};
+
+export default config;

--- a/apps/notebook/src/app/globals.css
+++ b/apps/notebook/src/app/globals.css
@@ -1,0 +1,299 @@
+@import "tailwindcss";
+
+@custom-variant dark (&:where(.dark, .dark *));
+
+/* === Brand Design Tokens === */
+:root {
+  --background: #F7F7F9;
+  --foreground: #010507;
+
+  --color-lilac:       #BEC2FF;
+  --color-lilac-light: #D4D7FF;
+  --color-lilac-dark:  #9599CC;
+  --color-mint:        #85E0CE;
+  --color-mint-light:  #A8E9DC;
+  --color-mint-dark:   #1B936F;
+
+  --color-surface:       #DEDEE9;
+  --color-surface-light: #F7F7F9;
+  --color-container:     #FFFFFF;
+
+  --color-text-primary:   #010507;
+  --color-text-secondary: #57575B;
+  --color-text-tertiary:  #8E8E93;
+
+  --color-border:        #DBDBE5;
+  --color-border-light:  #EBEBF0;
+  --color-border-glass:  rgba(255, 255, 255, 0.3);
+
+  --color-glass:        rgba(255, 255, 255, 0.7);
+  --color-glass-subtle: rgba(255, 255, 255, 0.5);
+  --color-glass-dark:   rgba(255, 255, 255, 0.85);
+
+  --shadow-sm:        0 1px 2px rgba(0, 0, 0, 0.05);
+  --shadow-md:        0 4px 6px -1px rgba(0, 0, 0, 0.07), 0 2px 4px -1px rgba(0, 0, 0, 0.04);
+  --shadow-lg:        0 10px 25px -3px rgba(0, 0, 0, 0.08), 0 4px 6px -2px rgba(0, 0, 0, 0.03);
+  --shadow-glass:     0 4px 30px rgba(0, 0, 0, 0.1);
+
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-8: 32px;
+
+  --radius-sm:  6px;
+  --radius-md:  8px;
+  --radius-lg:  12px;
+  --radius-xl:  16px;
+  --radius-2xl: 24px;
+
+  --font-family: 'Plus Jakarta Sans', system-ui, -apple-system, sans-serif;
+
+  --surface-primary:    #fff;
+  --surface-secondary:  #fafafa;
+  --text-primary:   #374151;
+  --text-secondary: #6b7280;
+  --text-tertiary:  #9ca3af;
+
+  --border-default: #e5e7eb;
+  --border-subtle:  #f0f0f0;
+
+  color-scheme: light dark;
+}
+
+/* === Dark Mode === */
+:root.dark {
+  --background: #0a0a0a;
+  --foreground: #ededed;
+
+  --color-surface:       #1a1a2e;
+  --color-surface-light: #0f0f1a;
+  --color-container:     #1a1a2e;
+
+  --color-text-primary:   #e5e7eb;
+  --color-text-secondary: #9ca3af;
+  --color-text-tertiary:  #6b7280;
+
+  --color-border:        rgba(255, 255, 255, 0.1);
+  --color-border-light:  rgba(255, 255, 255, 0.06);
+  --color-border-glass:  rgba(255, 255, 255, 0.08);
+
+  --color-glass:        rgba(20, 20, 40, 0.7);
+  --color-glass-subtle: rgba(20, 20, 40, 0.5);
+  --color-glass-dark:   rgba(10, 10, 20, 0.85);
+
+  --shadow-glass:      0 4px 30px rgba(0, 0, 0, 0.3);
+
+  --surface-primary:       rgba(255, 255, 255, 0.04);
+  --surface-secondary:     rgba(255, 255, 255, 0.02);
+
+  --text-primary:   #e5e7eb;
+  --text-secondary: #9ca3af;
+  --text-tertiary:  #6b7280;
+
+  --border-default: rgba(255, 255, 255, 0.08);
+  --border-subtle:  rgba(255, 255, 255, 0.06);
+}
+
+/* === Base === */
+body {
+  font-family: var(--font-family);
+  background: var(--background);
+  color: var(--foreground);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+
+body, html {
+  height: 100%;
+}
+
+/* === Animated Background === */
+.abstract-bg {
+  position: fixed;
+  inset: 0;
+  overflow: hidden;
+  z-index: 0;
+  background: linear-gradient(135deg, var(--color-surface-light) 0%, var(--color-surface) 100%);
+}
+
+.abstract-bg::before,
+.abstract-bg::after {
+  content: '';
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(80px);
+  opacity: 0.4;
+}
+
+.abstract-bg::before {
+  width: 600px;
+  height: 600px;
+  background: var(--color-lilac);
+  top: -200px;
+  right: -100px;
+  animation: blob1 25s ease-in-out infinite;
+}
+
+.abstract-bg::after {
+  width: 500px;
+  height: 500px;
+  background: var(--color-mint);
+  bottom: -150px;
+  left: -100px;
+  animation: blob2 30s ease-in-out infinite;
+}
+
+@keyframes blob1 {
+  0%, 100% { transform: translate(0, 0) scale(1); }
+  25%      { transform: translate(-30px, 50px) scale(1.1); }
+  50%      { transform: translate(20px, -30px) scale(0.95); }
+  75%      { transform: translate(40px, 20px) scale(1.05); }
+}
+
+@keyframes blob2 {
+  0%, 100% { transform: translate(0, 0) scale(1); }
+  33%      { transform: translate(50px, -40px) scale(1.1); }
+  66%      { transform: translate(-30px, 30px) scale(0.9); }
+}
+
+/* === Glassmorphism === */
+.glass {
+  background: var(--color-glass);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: 1px solid var(--color-border-glass);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-glass);
+}
+
+.glass-subtle {
+  background: var(--color-glass-subtle);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  border: 1px solid var(--color-border-glass);
+  border-radius: var(--radius-lg);
+}
+
+/* === Gradient Utilities === */
+.text-gradient {
+  background: linear-gradient(135deg, var(--color-lilac-dark), var(--color-mint-dark));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+/* === Notebook-specific === */
+.notebook-cell {
+  background: var(--color-glass);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: 1px solid var(--color-border-glass);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
+  transition: box-shadow 0.2s ease;
+}
+
+.notebook-cell:hover {
+  box-shadow: var(--shadow-md);
+}
+
+/* Code block styling */
+.code-block {
+  border-left: 3px solid var(--color-lilac);
+  overflow-x: auto;
+}
+
+.code-block pre {
+  margin: 0;
+  padding: var(--space-4);
+  font-size: 13px;
+  line-height: 1.6;
+  font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+}
+
+.code-block code {
+  font-family: inherit;
+}
+
+/* Markdown cell prose */
+.markdown-prose h1 { font-size: 1.75rem; font-weight: 700; margin-bottom: 0.75rem; }
+.markdown-prose h2 { font-size: 1.375rem; font-weight: 600; margin-bottom: 0.5rem; margin-top: 1.5rem; }
+.markdown-prose h3 { font-size: 1.125rem; font-weight: 600; margin-bottom: 0.5rem; margin-top: 1rem; }
+.markdown-prose p { margin-bottom: 0.75rem; color: var(--text-primary); }
+.markdown-prose ul, .markdown-prose ol { margin-bottom: 0.75rem; padding-left: 1.5rem; }
+.markdown-prose li { margin-bottom: 0.25rem; color: var(--text-primary); }
+.markdown-prose strong { font-weight: 600; }
+.markdown-prose a { color: var(--color-lilac-dark); text-decoration: underline; }
+.markdown-prose code {
+  background: var(--color-glass-subtle);
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 0.875em;
+  font-family: 'SF Mono', 'Fira Code', monospace;
+}
+.markdown-prose blockquote {
+  border-left: 3px solid var(--color-lilac);
+  padding: var(--space-3) var(--space-4);
+  margin: 0.75rem 0;
+  background: var(--color-glass-subtle);
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+}
+.markdown-prose blockquote p { margin: 0; color: var(--text-secondary); }
+.markdown-prose hr {
+  border: none;
+  border-top: 1px solid var(--color-border-light);
+  margin: 1.5rem 0;
+}
+
+/* Sidebar */
+.sidebar-link {
+  transition: all 0.15s ease;
+  border-left: 2px solid transparent;
+}
+
+.sidebar-link:hover {
+  background: var(--color-glass-subtle);
+}
+
+.sidebar-link--active {
+  border-left-color: var(--color-lilac-dark);
+  background: var(--color-glass-subtle);
+  color: var(--color-text-primary);
+  font-weight: 600;
+}
+
+/* Playground */
+.playground-container {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0;
+  min-height: 300px;
+  overflow: hidden;
+}
+
+@media (max-width: 768px) {
+  .playground-container {
+    grid-template-columns: 1fr;
+    grid-template-rows: 1fr 1fr;
+  }
+}
+
+/* Shimmer loading */
+@keyframes shimmer {
+  0%   { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+.shimmer-loading {
+  background: linear-gradient(
+    90deg,
+    var(--color-glass-subtle) 25%,
+    var(--color-glass) 50%,
+    var(--color-glass-subtle) 75%
+  );
+  background-size: 200% 100%;
+  animation: shimmer 1.5s ease-in-out infinite;
+}

--- a/apps/notebook/src/app/layout.tsx
+++ b/apps/notebook/src/app/layout.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import "./globals.css";
+import { ThemeProvider } from "@/hooks/use-theme";
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>OpenGenerativeUI Notebook</title>
+        <link
+          rel="icon"
+          href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>📓</text></svg>"
+        />
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap"
+          rel="stylesheet"
+        />
+      </head>
+      <body className="antialiased">
+        <ThemeProvider>{children}</ThemeProvider>
+      </body>
+    </html>
+  );
+}

--- a/apps/notebook/src/app/page.tsx
+++ b/apps/notebook/src/app/page.tsx
@@ -1,0 +1,5 @@
+import { NotebookShell } from "@/components/notebook-shell";
+
+export default function Page() {
+  return <NotebookShell />;
+}

--- a/apps/notebook/src/components/cell-renderer.tsx
+++ b/apps/notebook/src/components/cell-renderer.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import type { Cell } from "@/lib/types";
+import { MarkdownCell } from "./markdown-cell";
+import { CodeCell } from "./code-cell";
+
+const PlaygroundCell = dynamic(
+  () => import("./playground-cell").then((m) => m.PlaygroundCell),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="notebook-cell overflow-hidden" style={{ minHeight: 300 }}>
+        <div className="shimmer-loading w-full h-full" style={{ minHeight: 300 }} />
+      </div>
+    ),
+  }
+);
+
+export function CellRenderer({ cell }: { cell: Cell }) {
+  switch (cell.type) {
+    case "markdown":
+      return <MarkdownCell content={cell.content} />;
+    case "code":
+      return (
+        <CodeCell
+          content={cell.content}
+          language={cell.language}
+          filename={cell.filename}
+        />
+      );
+    case "playground":
+      return (
+        <PlaygroundCell
+          files={cell.files}
+          dependencies={cell.dependencies}
+          title={cell.title}
+        />
+      );
+  }
+}

--- a/apps/notebook/src/components/cell-renderer.tsx
+++ b/apps/notebook/src/components/cell-renderer.tsx
@@ -17,6 +17,18 @@ const PlaygroundCell = dynamic(
   }
 );
 
+const MermaidCell = dynamic(
+  () => import("./mermaid-cell").then((m) => m.MermaidCell),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="notebook-cell overflow-hidden" style={{ minHeight: 200 }}>
+        <div className="shimmer-loading w-full h-full" style={{ minHeight: 200 }} />
+      </div>
+    ),
+  }
+);
+
 export function CellRenderer({ cell }: { cell: Cell }) {
   switch (cell.type) {
     case "markdown":
@@ -37,5 +49,7 @@ export function CellRenderer({ cell }: { cell: Cell }) {
           title={cell.title}
         />
       );
+    case "mermaid":
+      return <MermaidCell content={cell.content} title={cell.title} />;
   }
 }

--- a/apps/notebook/src/components/chapter-header.tsx
+++ b/apps/notebook/src/components/chapter-header.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+export function ChapterHeader({
+  icon,
+  title,
+  description,
+}: {
+  icon: string;
+  title: string;
+  description: string;
+}) {
+  return (
+    <div className="flex items-start gap-4 mb-6">
+      <span
+        className="flex items-center justify-center w-10 h-10 rounded-xl text-lg flex-shrink-0"
+        style={{
+          background: "linear-gradient(135deg, var(--color-lilac), var(--color-mint))",
+        }}
+      >
+        {icon}
+      </span>
+      <div>
+        <h2 className="text-xl font-bold text-gradient m-0">{title}</h2>
+        <p className="text-sm mt-1" style={{ color: "var(--text-secondary)" }}>
+          {description}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/notebook/src/components/code-cell.tsx
+++ b/apps/notebook/src/components/code-cell.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { getHighlighter } from "@/lib/highlight";
+import { CopyButton } from "./copy-button";
+
+export function CodeCell({
+  content,
+  language,
+  filename,
+}: {
+  content: string;
+  language: string;
+  filename?: string;
+}) {
+  const [html, setHtml] = useState<string>("");
+  const [isDark, setIsDark] = useState(false);
+
+  useEffect(() => {
+    const check = () =>
+      setIsDark(document.documentElement.classList.contains("dark"));
+    check();
+    const observer = new MutationObserver(check);
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class"],
+    });
+    return () => observer.disconnect();
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    getHighlighter().then((highlighter) => {
+      if (cancelled) return;
+      const theme = isDark ? "github-dark" : "github-light";
+      const highlighted = highlighter.codeToHtml(content.trim(), {
+        lang: language,
+        theme,
+      });
+      setHtml(highlighted);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [content, language, isDark]);
+
+  return (
+    <div className="notebook-cell group relative code-block overflow-hidden">
+      {filename && (
+        <div
+          className="px-4 py-2 text-xs font-medium border-b"
+          style={{
+            color: "var(--text-secondary)",
+            borderColor: "var(--color-border-glass)",
+            background: "var(--color-glass-subtle)",
+          }}
+        >
+          {filename}
+        </div>
+      )}
+      <CopyButton text={content.trim()} />
+      {html ? (
+        <div
+          dangerouslySetInnerHTML={{ __html: html }}
+          className="[&_pre]:!bg-transparent [&_pre]:p-4 [&_pre]:text-[13px] [&_pre]:leading-relaxed [&_code]:font-mono"
+        />
+      ) : (
+        <div className="p-4">
+          <pre className="text-[13px] leading-relaxed font-mono" style={{ color: "var(--text-primary)" }}>
+            <code>{content.trim()}</code>
+          </pre>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/notebook/src/components/copy-button.tsx
+++ b/apps/notebook/src/components/copy-button.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useState } from "react";
+
+export function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <button
+      onClick={handleCopy}
+      className="absolute top-2 right-2 px-2 py-1 text-xs rounded-md opacity-0 group-hover:opacity-100 transition-opacity"
+      style={{
+        background: "var(--color-glass-subtle)",
+        border: "1px solid var(--color-border-glass)",
+        color: "var(--text-secondary)",
+      }}
+    >
+      {copied ? "Copied!" : "Copy"}
+    </button>
+  );
+}

--- a/apps/notebook/src/components/markdown-cell.tsx
+++ b/apps/notebook/src/components/markdown-cell.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+export function MarkdownCell({ content }: { content: string }) {
+  return (
+    <div className="notebook-cell p-5 md:p-6">
+      <div className="markdown-prose">
+        <ReactMarkdown
+          remarkPlugins={[remarkGfm]}
+          components={{
+            h1: ({ children }) => (
+              <h1 className="text-gradient">{children}</h1>
+            ),
+            h2: ({ children }) => (
+              <h2 className="text-gradient">{children}</h2>
+            ),
+            a: ({ href, children }) => (
+              <a href={href} target="_blank" rel="noopener noreferrer">
+                {children}
+              </a>
+            ),
+          }}
+        >
+          {content}
+        </ReactMarkdown>
+      </div>
+    </div>
+  );
+}

--- a/apps/notebook/src/components/mermaid-cell.tsx
+++ b/apps/notebook/src/components/mermaid-cell.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useEffect, useState, useId } from "react";
+import mermaid from "mermaid";
+
+let initialized = false;
+
+function initMermaid(isDark: boolean) {
+  mermaid.initialize({
+    startOnLoad: false,
+    theme: isDark ? "dark" : "default",
+    fontFamily: "'Plus Jakarta Sans', system-ui, sans-serif",
+    fontSize: 14,
+  });
+  initialized = true;
+}
+
+export function MermaidCell({
+  content,
+  title,
+}: {
+  content: string;
+  title?: string;
+}) {
+  const [svg, setSvg] = useState<string>("");
+  const [error, setError] = useState<string>("");
+  const [isDark, setIsDark] = useState(false);
+  const reactId = useId();
+  const safeId = "mermaid-" + reactId.replace(/:/g, "-");
+
+  // Dark mode detection
+  useEffect(() => {
+    const check = () =>
+      setIsDark(document.documentElement.classList.contains("dark"));
+    check();
+    const observer = new MutationObserver(check);
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class"],
+    });
+    return () => observer.disconnect();
+  }, []);
+
+  // Render diagram
+  useEffect(() => {
+    let cancelled = false;
+
+    async function render() {
+      try {
+        // Re-initialize to pick up theme change
+        initMermaid(isDark);
+
+        const { svg: rendered } = await mermaid.render(safeId, content.trim());
+        if (!cancelled) {
+          setSvg(rendered);
+          setError("");
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : "Failed to render diagram");
+          setSvg("");
+        }
+        // Clean up orphaned element mermaid may have left
+        const orphan = document.getElementById("d" + safeId);
+        orphan?.remove();
+      }
+    }
+
+    render();
+    return () => {
+      cancelled = true;
+    };
+  }, [content, isDark, safeId]);
+
+  return (
+    <div
+      className="notebook-cell overflow-hidden"
+      style={{ borderLeft: "3px solid var(--color-mint)" }}
+    >
+      {title && (
+        <div
+          className="px-4 py-2.5 text-sm font-semibold flex items-center gap-2 border-b"
+          style={{
+            borderColor: "var(--color-border-glass)",
+            background: "var(--color-glass-subtle)",
+          }}
+        >
+          <span
+            className="inline-flex items-center justify-center w-5 h-5 rounded text-xs"
+            style={{
+              background:
+                "linear-gradient(135deg, var(--color-lilac), var(--color-mint))",
+              color: "#fff",
+            }}
+          >
+            &#9670;
+          </span>
+          <span style={{ color: "var(--text-primary)" }}>{title}</span>
+        </div>
+      )}
+
+      <div className="p-4 flex justify-center">
+        {error ? (
+          <div
+            className="text-sm p-3 rounded-md w-full"
+            style={{
+              background: "var(--color-glass-subtle)",
+              color: "var(--text-secondary)",
+              fontFamily: "monospace",
+            }}
+          >
+            Diagram error: {error}
+          </div>
+        ) : svg ? (
+          <div
+            dangerouslySetInnerHTML={{ __html: svg }}
+            className="[&>svg]:max-w-full [&>svg]:h-auto"
+          />
+        ) : (
+          <div
+            className="shimmer-loading rounded-md"
+            style={{ width: "100%", height: 200 }}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/notebook/src/components/notebook-shell.tsx
+++ b/apps/notebook/src/components/notebook-shell.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { chapters } from "@/content";
+import { SidebarNav } from "./sidebar-nav";
+import { ChapterHeader } from "./chapter-header";
+import { CellRenderer } from "./cell-renderer";
+import { ThemeToggle } from "./theme-toggle";
+
+export function NotebookShell() {
+  return (
+    <div className="min-h-screen">
+      {/* Animated background */}
+      <div className="abstract-bg" />
+
+      <SidebarNav chapters={chapters} />
+
+      {/* Main content */}
+      <main className="relative z-10 md:ml-60">
+        {/* Top bar */}
+        <div
+          className="sticky top-0 z-20 flex items-center justify-end px-6 py-3"
+          style={{
+            background: "var(--color-glass-dark)",
+            borderBottom: "1px solid var(--color-border-glass)",
+            backdropFilter: "blur(16px)",
+          }}
+        >
+          <ThemeToggle />
+        </div>
+
+        {/* Chapters */}
+        <div className="max-w-3xl mx-auto px-4 md:px-8 py-8 pb-32">
+          {chapters.map((chapter) => (
+            <section key={chapter.id} id={chapter.id} className="mb-16 scroll-mt-16">
+              <ChapterHeader
+                icon={chapter.icon}
+                title={chapter.title}
+                description={chapter.description}
+              />
+              <div className="flex flex-col gap-4">
+                {chapter.cells.map((cell) => (
+                  <CellRenderer key={cell.id} cell={cell} />
+                ))}
+              </div>
+            </section>
+          ))}
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/apps/notebook/src/components/playground-cell.tsx
+++ b/apps/notebook/src/components/playground-cell.tsx
@@ -7,7 +7,7 @@ import {
   SandpackLayout,
   useSandpack,
 } from "@codesandbox/sandpack-react";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 
 function ResetButton() {
   const { sandpack } = useSandpack();
@@ -36,6 +36,7 @@ export function PlaygroundCell({
   title?: string;
 }) {
   const [isDark, setIsDark] = useState(false);
+  const [isFullscreen, setIsFullscreen] = useState(false);
 
   useEffect(() => {
     const check = () =>
@@ -48,6 +49,23 @@ export function PlaygroundCell({
     });
     return () => observer.disconnect();
   }, []);
+
+  // Close fullscreen on Escape
+  useEffect(() => {
+    if (!isFullscreen) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setIsFullscreen(false);
+    };
+    document.addEventListener("keydown", handler);
+    // Prevent body scroll while fullscreen
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.removeEventListener("keydown", handler);
+      document.body.style.overflow = "";
+    };
+  }, [isFullscreen]);
+
+  const toggleFullscreen = useCallback(() => setIsFullscreen((v) => !v), []);
 
   const sandpackTheme = {
     colors: {
@@ -70,26 +88,89 @@ export function PlaygroundCell({
     },
   };
 
+  const wrapperClass = isFullscreen
+    ? "fixed inset-0 z-50 flex flex-col"
+    : "notebook-cell overflow-hidden";
+
+  const wrapperStyle = isFullscreen
+    ? {
+        background: isDark ? "#0a0a0a" : "#ffffff",
+        borderColor: "var(--color-mint)",
+      }
+    : { borderColor: "var(--color-mint)" };
+
   return (
-    <div className="notebook-cell overflow-hidden" style={{ borderColor: "var(--color-mint)" }}>
+    <div className={wrapperClass} style={wrapperStyle}>
+      {/* Header bar */}
       {title && (
         <div
-          className="px-4 py-2.5 text-sm font-semibold flex items-center gap-2 border-b"
+          className="px-4 py-2.5 text-sm font-semibold flex items-center gap-2 border-b shrink-0"
           style={{
             borderColor: "var(--color-border-glass)",
-            background: "var(--color-glass-subtle)",
+            background: isFullscreen
+              ? isDark
+                ? "#1a1a2e"
+                : "#f7f7f9"
+              : "var(--color-glass-subtle)",
           }}
         >
           <span
             className="inline-flex items-center justify-center w-5 h-5 rounded text-xs"
             style={{
-              background: "linear-gradient(135deg, var(--color-lilac), var(--color-mint))",
+              background:
+                "linear-gradient(135deg, var(--color-lilac), var(--color-mint))",
               color: "#fff",
             }}
           >
             &#9654;
           </span>
-          <span style={{ color: "var(--text-primary)" }}>{title}</span>
+          <span className="flex-1" style={{ color: "var(--text-primary)" }}>
+            {title}
+          </span>
+          <button
+            onClick={toggleFullscreen}
+            className="flex items-center justify-center w-7 h-7 rounded-md transition-colors cursor-pointer"
+            style={{
+              background: "var(--color-glass-subtle)",
+              border: "1px solid var(--color-border-glass)",
+              color: "var(--text-secondary)",
+            }}
+            title={isFullscreen ? "Exit fullscreen (Esc)" : "Fullscreen"}
+          >
+            {isFullscreen ? (
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <polyline points="4 14 10 14 10 20" />
+                <polyline points="20 10 14 10 14 4" />
+                <line x1="14" y1="10" x2="21" y2="3" />
+                <line x1="3" y1="21" x2="10" y2="14" />
+              </svg>
+            ) : (
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <polyline points="15 3 21 3 21 9" />
+                <polyline points="9 21 3 21 3 15" />
+                <line x1="21" y1="3" x2="14" y2="10" />
+                <line x1="3" y1="21" x2="10" y2="14" />
+              </svg>
+            )}
+          </button>
         </div>
       )}
 
@@ -111,25 +192,27 @@ export function PlaygroundCell({
         }}
       >
         <SandpackLayout
+          className={isFullscreen ? "flex-1" : ""}
           style={{
             border: "none",
             borderRadius: 0,
             background: "transparent",
+            ...(isFullscreen ? { height: "100%" } : {}),
           }}
         >
           <SandpackCodeEditor
             showLineNumbers
             showTabs
-            style={{ minHeight: 280 }}
+            style={{ minHeight: isFullscreen ? undefined : 280 }}
           />
           <SandpackPreview
             showOpenInCodeSandbox={false}
             showRefreshButton
-            style={{ minHeight: 280 }}
+            style={{ minHeight: isFullscreen ? undefined : 280 }}
           />
         </SandpackLayout>
         <div
-          className="flex items-center gap-2 px-4 py-2 border-t"
+          className="flex items-center gap-2 px-4 py-2 border-t shrink-0"
           style={{ borderColor: "var(--color-border-glass)" }}
         >
           <ResetButton />

--- a/apps/notebook/src/components/playground-cell.tsx
+++ b/apps/notebook/src/components/playground-cell.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import {
+  SandpackProvider,
+  SandpackCodeEditor,
+  SandpackPreview,
+  SandpackLayout,
+  useSandpack,
+} from "@codesandbox/sandpack-react";
+import { useEffect, useState } from "react";
+
+function ResetButton() {
+  const { sandpack } = useSandpack();
+  return (
+    <button
+      onClick={() => sandpack.resetAllFiles()}
+      className="px-3 py-1.5 text-xs font-medium rounded-md transition-colors cursor-pointer"
+      style={{
+        background: "var(--color-glass-subtle)",
+        border: "1px solid var(--color-border-glass)",
+        color: "var(--text-secondary)",
+      }}
+    >
+      Reset
+    </button>
+  );
+}
+
+export function PlaygroundCell({
+  files,
+  dependencies,
+  title,
+}: {
+  files: Record<string, string>;
+  dependencies?: Record<string, string>;
+  title?: string;
+}) {
+  const [isDark, setIsDark] = useState(false);
+
+  useEffect(() => {
+    const check = () =>
+      setIsDark(document.documentElement.classList.contains("dark"));
+    check();
+    const observer = new MutationObserver(check);
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class"],
+    });
+    return () => observer.disconnect();
+  }, []);
+
+  const sandpackTheme = {
+    colors: {
+      surface1: isDark ? "#1a1a2e" : "#ffffff",
+      surface2: isDark ? "#0f0f1a" : "#f7f7f9",
+      surface3: isDark ? "#2a2a4a" : "#ebebf0",
+      clickable: isDark ? "#9ca3af" : "#6b7280",
+      base: isDark ? "#e5e7eb" : "#374151",
+      disabled: isDark ? "#4b5563" : "#d1d5db",
+      hover: isDark ? "#d1d5db" : "#111827",
+      accent: isDark ? "#BEC2FF" : "#9599CC",
+      error: "#ef4444",
+      errorSurface: isDark ? "#451a1a" : "#fef2f2",
+    },
+    font: {
+      body: "'Plus Jakarta Sans', system-ui, sans-serif",
+      mono: "'SF Mono', 'Fira Code', monospace",
+      size: "13px",
+      lineHeight: "1.6",
+    },
+  };
+
+  return (
+    <div className="notebook-cell overflow-hidden" style={{ borderColor: "var(--color-mint)" }}>
+      {title && (
+        <div
+          className="px-4 py-2.5 text-sm font-semibold flex items-center gap-2 border-b"
+          style={{
+            borderColor: "var(--color-border-glass)",
+            background: "var(--color-glass-subtle)",
+          }}
+        >
+          <span
+            className="inline-flex items-center justify-center w-5 h-5 rounded text-xs"
+            style={{
+              background: "linear-gradient(135deg, var(--color-lilac), var(--color-mint))",
+              color: "#fff",
+            }}
+          >
+            &#9654;
+          </span>
+          <span style={{ color: "var(--text-primary)" }}>{title}</span>
+        </div>
+      )}
+
+      <SandpackProvider
+        template="react"
+        theme={sandpackTheme}
+        files={files}
+        customSetup={{
+          dependencies: {
+            react: "^18.2.0",
+            "react-dom": "^18.2.0",
+            ...dependencies,
+          },
+        }}
+        options={{
+          externalResources: [
+            "https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap",
+          ],
+        }}
+      >
+        <SandpackLayout
+          style={{
+            border: "none",
+            borderRadius: 0,
+            background: "transparent",
+          }}
+        >
+          <SandpackCodeEditor
+            showLineNumbers
+            showTabs
+            style={{ minHeight: 280 }}
+          />
+          <SandpackPreview
+            showOpenInCodeSandbox={false}
+            showRefreshButton
+            style={{ minHeight: 280 }}
+          />
+        </SandpackLayout>
+        <div
+          className="flex items-center gap-2 px-4 py-2 border-t"
+          style={{ borderColor: "var(--color-border-glass)" }}
+        >
+          <ResetButton />
+          <span className="text-xs" style={{ color: "var(--text-tertiary)" }}>
+            Edit the code and see changes live
+          </span>
+        </div>
+      </SandpackProvider>
+    </div>
+  );
+}

--- a/apps/notebook/src/components/sidebar-nav.tsx
+++ b/apps/notebook/src/components/sidebar-nav.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { Chapter } from "@/lib/types";
+
+export function SidebarNav({ chapters }: { chapters: Chapter[] }) {
+  const [activeId, setActiveId] = useState<string>(chapters[0]?.id ?? "");
+  const [isOpen, setIsOpen] = useState(false);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const visible = entries.find((e) => e.isIntersecting);
+        if (visible) setActiveId(visible.target.id);
+      },
+      { rootMargin: "-80px 0px -60% 0px", threshold: 0.1 }
+    );
+
+    chapters.forEach((ch) => {
+      const el = document.getElementById(ch.id);
+      if (el) observer.observe(el);
+    });
+
+    return () => observer.disconnect();
+  }, [chapters]);
+
+  const scrollTo = (id: string) => {
+    document.getElementById(id)?.scrollIntoView({ behavior: "smooth" });
+    setIsOpen(false);
+  };
+
+  return (
+    <>
+      {/* Mobile hamburger */}
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="fixed top-4 left-4 z-50 md:hidden flex items-center justify-center w-10 h-10 rounded-lg cursor-pointer"
+        style={{
+          background: "var(--color-glass-dark)",
+          border: "1px solid var(--color-border-glass)",
+          backdropFilter: "blur(12px)",
+        }}
+      >
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+          {isOpen ? (
+            <>
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </>
+          ) : (
+            <>
+              <line x1="3" y1="6" x2="21" y2="6" />
+              <line x1="3" y1="12" x2="21" y2="12" />
+              <line x1="3" y1="18" x2="21" y2="18" />
+            </>
+          )}
+        </svg>
+      </button>
+
+      {/* Overlay for mobile */}
+      {isOpen && (
+        <div
+          className="fixed inset-0 z-30 md:hidden"
+          style={{ background: "rgba(0,0,0,0.3)" }}
+          onClick={() => setIsOpen(false)}
+        />
+      )}
+
+      {/* Sidebar */}
+      <aside
+        className={`fixed top-0 left-0 z-40 h-full w-60 flex flex-col pt-6 pb-4 transition-transform md:translate-x-0 ${
+          isOpen ? "translate-x-0" : "-translate-x-full"
+        }`}
+        style={{
+          background: "var(--color-glass-dark)",
+          borderRight: "1px solid var(--color-border-glass)",
+          backdropFilter: "blur(16px)",
+        }}
+      >
+        <div className="px-5 mb-6">
+          <h1 className="text-sm font-bold text-gradient">OpenGenerativeUI</h1>
+          <p className="text-xs mt-0.5" style={{ color: "var(--text-tertiary)" }}>
+            Interactive Notebook
+          </p>
+        </div>
+
+        <nav className="flex-1 overflow-y-auto px-3">
+          {chapters.map((ch, i) => (
+            <button
+              key={ch.id}
+              onClick={() => scrollTo(ch.id)}
+              className={`sidebar-link w-full text-left px-3 py-2 rounded-md text-sm mb-0.5 cursor-pointer ${
+                activeId === ch.id ? "sidebar-link--active" : ""
+              }`}
+              style={{
+                color: activeId === ch.id ? "var(--color-text-primary)" : "var(--text-secondary)",
+              }}
+            >
+              <span className="mr-2">{ch.icon}</span>
+              <span className="text-xs font-medium" style={{ color: "var(--text-tertiary)" }}>
+                {String(i + 1).padStart(2, "0")}
+              </span>{" "}
+              {ch.title}
+            </button>
+          ))}
+        </nav>
+      </aside>
+    </>
+  );
+}

--- a/apps/notebook/src/components/theme-toggle.tsx
+++ b/apps/notebook/src/components/theme-toggle.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useTheme } from "@/hooks/use-theme";
+
+export function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+
+  const isDark =
+    theme === "dark" ||
+    (theme === "system" && typeof window !== "undefined" && window.matchMedia("(prefers-color-scheme: dark)").matches);
+
+  return (
+    <button
+      onClick={() => setTheme(isDark ? "light" : "dark")}
+      className="flex items-center justify-center w-8 h-8 rounded-lg transition-colors cursor-pointer"
+      style={{
+        background: "var(--color-glass-subtle)",
+        border: "1px solid var(--color-border-glass)",
+      }}
+      aria-label="Toggle theme"
+    >
+      {isDark ? (
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <circle cx="12" cy="12" r="5" />
+          <line x1="12" y1="1" x2="12" y2="3" />
+          <line x1="12" y1="21" x2="12" y2="23" />
+          <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+          <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+          <line x1="1" y1="12" x2="3" y2="12" />
+          <line x1="21" y1="12" x2="23" y2="12" />
+          <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+          <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+        </svg>
+      ) : (
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+        </svg>
+      )}
+    </button>
+  );
+}

--- a/apps/notebook/src/content/chapters/01-introduction.ts
+++ b/apps/notebook/src/content/chapters/01-introduction.ts
@@ -20,13 +20,26 @@ The agent produces charts, 3D scenes, SVG diagrams, and interactive widgets that
       id: "intro-arch",
       content: `## Architecture
 
-Three systems work together:
+Three systems work together in a layered architecture:`,
+    },
+    {
+      type: "mermaid",
+      id: "intro-arch-diagram",
+      title: "System Architecture",
+      content: `graph TD
+    User([User]) -->|chat message| CK[CopilotKit\nReact hooks + runtime]
+    CK -->|forwards to agent| DA[Deep Agent\nLangGraph + tools + skills]
+    DA -->|tool calls| Tools{Tools}
+    Tools -->|plan_visualization| DA
+    Tools -->|widgetRenderer| WR[Widget Renderer\nSandboxed iframe + Idiomorph]
+    Tools -->|pieChart / barChart| WR
+    WR -->|renders in browser| User
 
-| Layer | Tech | Role |
-|-------|------|------|
-| **Widget Renderer** | Sandboxed iframe, Idiomorph | Renders agent-generated HTML/SVG/3D in the browser |
-| **CopilotKit** | React hooks, runtime API | Bridges the React frontend to the agent backend |
-| **Deep Agent** | LangGraph, \`create_deep_agent\` | Orchestrates tools, manages state, follows a mandatory visualization workflow |`,
+    style CK fill:#EDE9F5,stroke:#5B3FA0,color:#3E2B6F
+    style DA fill:#E3EFFC,stroke:#2663B3,color:#1A4680
+    style WR fill:#E1F5EE,stroke:#0F6E56,color:#085041
+    style User fill:#f7f6f3,stroke:#9c9a92,color:#1a1a1a
+    style Tools fill:#FAEEDA,stroke:#B8860B,color:#854F0B`,
     },
     {
       type: "code",

--- a/apps/notebook/src/content/chapters/01-introduction.ts
+++ b/apps/notebook/src/content/chapters/01-introduction.ts
@@ -1,0 +1,74 @@
+import type { Chapter } from "@/lib/types";
+
+export const introduction: Chapter = {
+  id: "introduction",
+  title: "Introduction",
+  description: "What is OpenGenerativeUI and how does it work?",
+  icon: "🪁",
+  cells: [
+    {
+      type: "markdown",
+      id: "intro-what",
+      content: `# Welcome to OpenGenerativeUI
+
+OpenGenerativeUI is an open-source template that demonstrates **AI agent-driven UI** using [CopilotKit](https://copilotkit.ai) and [LangGraph](https://langchain-ai.github.io/langgraph/).
+
+Unlike traditional chatbots that only produce text, this project shows how an AI agent can **directly manipulate application state** — adding todos, generating charts, rendering interactive widgets — all while the user can interact with the same UI.
+
+## What makes this different?
+
+- **Agent-driven UI**: The AI doesn't just talk — it builds and modifies real UI components
+- **Bidirectional state sync**: Both the user and the agent can modify the same state
+- **Generative UI**: The agent produces rich, interactive components (charts, widgets, 3D visualizations) on the fly
+- **Human-in-the-loop**: The agent can pause and ask for user input when needed`,
+    },
+    {
+      type: "markdown",
+      id: "intro-architecture",
+      content: `## Architecture
+
+The project is a **Turborepo monorepo** with three main pieces:
+
+| Component | Tech | Purpose |
+|-----------|------|---------|
+| \`apps/app\` | Next.js 16, React 19 | Frontend with CopilotKit integration |
+| \`apps/agent\` | LangGraph, Python | AI agent with tools and state |
+| \`apps/mcp\` | MCP Server | Design system for external AI tools |
+
+The frontend communicates with the agent through CopilotKit's runtime, which bridges React hooks to the LangGraph agent backend.`,
+    },
+    {
+      type: "code",
+      id: "intro-monorepo",
+      language: "bash",
+      filename: "Project Structure",
+      content: `apps/
+├── app/          # Next.js frontend (React 19, TailwindCSS 4)
+│   └── src/
+│       ├── app/           # Pages & API routes
+│       ├── components/    # UI components
+│       └── hooks/         # CopilotKit hook registrations
+├── agent/        # LangGraph Python agent
+│   ├── main.py            # Agent entry point
+│   └── src/
+│       ├── todos.py       # Todo tools & state schema
+│       └── query.py       # Data query tool
+└── mcp/          # MCP design system server
+    └── skills/            # Agent skill documents`,
+    },
+    {
+      type: "markdown",
+      id: "intro-flow",
+      content: `## How it flows
+
+1. User opens the app and sees a chat interface alongside a todo canvas
+2. User types a message (e.g., "Add 3 todos for a weekend trip")
+3. CopilotKit sends the message to the LangGraph agent
+4. The agent calls the \`manage_todos\` tool to update state
+5. State syncs back to the frontend via CopilotKit
+6. The todo list UI updates reactively
+
+Let's dive into how each piece works, starting with **Agent State**.`,
+    },
+  ],
+};

--- a/apps/notebook/src/content/chapters/01-introduction.ts
+++ b/apps/notebook/src/content/chapters/01-introduction.ts
@@ -13,21 +13,20 @@ export const introduction: Chapter = {
 
 OpenGenerativeUI is an open-source template showing how an AI agent can **generate rich, interactive UI** — not just text — using [CopilotKit](https://copilotkit.ai) and [LangGraph](https://langchain-ai.github.io/langgraph/).
 
-The agent produces charts, 3D scenes, SVG diagrams, and interactive widgets that render directly in the chat stream. Users and the agent share the same application state, and the agent is guided by composable **skill documents** that define visual quality standards.`,
+The agent produces charts, 3D scenes, SVG diagrams, and interactive widgets that render directly in the chat stream. Users and the agent share the same application state.`,
     },
     {
       type: "markdown",
       id: "intro-arch",
       content: `## Architecture
 
-Four systems work together:
+Three systems work together:
 
 | Layer | Tech | Role |
 |-------|------|------|
 | **Widget Renderer** | Sandboxed iframe, Idiomorph | Renders agent-generated HTML/SVG/3D in the browser |
 | **CopilotKit** | React hooks, runtime API | Bridges the React frontend to the agent backend |
-| **Deep Agent** | LangGraph, \`create_deep_agent\` | Orchestrates tools, manages state, follows a mandatory visualization workflow |
-| **MCP Skills** | MCP server, \`.txt\` playbooks | Provides composable design system rules and rendering instructions |`,
+| **Deep Agent** | LangGraph, \`create_deep_agent\` | Orchestrates tools, manages state, follows a mandatory visualization workflow |`,
     },
     {
       type: "code",
@@ -44,22 +43,13 @@ Four systems work together:
 │       │   └── use-generative-ui-examples.tsx  # CopilotKit hook registrations
 │       └── app/
 │           └── api/copilotkit/route.ts   # CopilotKit runtime (connects to agent)
-├── agent/                  # LangGraph Python agent
-│   ├── main.py             # create_deep_agent + system prompt
-│   ├── skills/             # Agent skill documents (loaded at runtime)
-│   └── src/
-│       ├── todos.py        # AgentState schema + todo tools
-│       ├── plan.py         # Mandatory plan_visualization tool
-│       ├── query.py        # Data query tool
-│       └── bounded_memory_saver.py  # FIFO thread eviction
-└── mcp/                    # MCP design system server
-    ├── src/
-    │   ├── server.ts       # Resources, prompts, tools
-    │   └── renderer.ts     # Theme CSS + bridge JS assembly
-    └── skills/             # Playbook .txt files
-        ├── master-agent-playbook.txt
-        ├── svg-diagram-skill.txt
-        └── agent-skills-vol2.txt`,
+└── agent/                  # LangGraph Python agent
+    ├── main.py             # create_deep_agent + system prompt
+    └── src/
+        ├── todos.py        # AgentState schema + todo tools
+        ├── plan.py         # Mandatory plan_visualization tool
+        ├── query.py        # Data query tool
+        └── bounded_memory_saver.py  # FIFO thread eviction`,
     },
     {
       type: "markdown",

--- a/apps/notebook/src/content/chapters/01-introduction.ts
+++ b/apps/notebook/src/content/chapters/01-introduction.ts
@@ -3,72 +3,79 @@ import type { Chapter } from "@/lib/types";
 export const introduction: Chapter = {
   id: "introduction",
   title: "Introduction",
-  description: "What is OpenGenerativeUI and how does it work?",
+  description: "What OpenGenerativeUI is and how the pieces connect.",
   icon: "🪁",
   cells: [
     {
       type: "markdown",
       id: "intro-what",
-      content: `# Welcome to OpenGenerativeUI
+      content: `# OpenGenerativeUI
 
-OpenGenerativeUI is an open-source template that demonstrates **AI agent-driven UI** using [CopilotKit](https://copilotkit.ai) and [LangGraph](https://langchain-ai.github.io/langgraph/).
+OpenGenerativeUI is an open-source template showing how an AI agent can **generate rich, interactive UI** — not just text — using [CopilotKit](https://copilotkit.ai) and [LangGraph](https://langchain-ai.github.io/langgraph/).
 
-Unlike traditional chatbots that only produce text, this project shows how an AI agent can **directly manipulate application state** — adding todos, generating charts, rendering interactive widgets — all while the user can interact with the same UI.
-
-## What makes this different?
-
-- **Agent-driven UI**: The AI doesn't just talk — it builds and modifies real UI components
-- **Bidirectional state sync**: Both the user and the agent can modify the same state
-- **Generative UI**: The agent produces rich, interactive components (charts, widgets, 3D visualizations) on the fly
-- **Human-in-the-loop**: The agent can pause and ask for user input when needed`,
+The agent produces charts, 3D scenes, SVG diagrams, and interactive widgets that render directly in the chat stream. Users and the agent share the same application state, and the agent is guided by composable **skill documents** that define visual quality standards.`,
     },
     {
       type: "markdown",
-      id: "intro-architecture",
+      id: "intro-arch",
       content: `## Architecture
 
-The project is a **Turborepo monorepo** with three main pieces:
+Four systems work together:
 
-| Component | Tech | Purpose |
-|-----------|------|---------|
-| \`apps/app\` | Next.js 16, React 19 | Frontend with CopilotKit integration |
-| \`apps/agent\` | LangGraph, Python | AI agent with tools and state |
-| \`apps/mcp\` | MCP Server | Design system for external AI tools |
-
-The frontend communicates with the agent through CopilotKit's runtime, which bridges React hooks to the LangGraph agent backend.`,
+| Layer | Tech | Role |
+|-------|------|------|
+| **Widget Renderer** | Sandboxed iframe, Idiomorph | Renders agent-generated HTML/SVG/3D in the browser |
+| **CopilotKit** | React hooks, runtime API | Bridges the React frontend to the agent backend |
+| **Deep Agent** | LangGraph, \`create_deep_agent\` | Orchestrates tools, manages state, follows a mandatory visualization workflow |
+| **MCP Skills** | MCP server, \`.txt\` playbooks | Provides composable design system rules and rendering instructions |`,
     },
     {
       type: "code",
-      id: "intro-monorepo",
+      id: "intro-structure",
       language: "bash",
       filename: "Project Structure",
       content: `apps/
-├── app/          # Next.js frontend (React 19, TailwindCSS 4)
+├── app/                    # Next.js frontend
 │   └── src/
-│       ├── app/           # Pages & API routes
-│       ├── components/    # UI components
-│       └── hooks/         # CopilotKit hook registrations
-├── agent/        # LangGraph Python agent
-│   ├── main.py            # Agent entry point
+│       ├── components/
+│       │   └── generative-ui/
+│       │       └── widget-renderer.tsx   # The iframe rendering engine
+│       ├── hooks/
+│       │   └── use-generative-ui-examples.tsx  # CopilotKit hook registrations
+│       └── app/
+│           └── api/copilotkit/route.ts   # CopilotKit runtime (connects to agent)
+├── agent/                  # LangGraph Python agent
+│   ├── main.py             # create_deep_agent + system prompt
+│   ├── skills/             # Agent skill documents (loaded at runtime)
 │   └── src/
-│       ├── todos.py       # Todo tools & state schema
-│       └── query.py       # Data query tool
-└── mcp/          # MCP design system server
-    └── skills/            # Agent skill documents`,
+│       ├── todos.py        # AgentState schema + todo tools
+│       ├── plan.py         # Mandatory plan_visualization tool
+│       ├── query.py        # Data query tool
+│       └── bounded_memory_saver.py  # FIFO thread eviction
+└── mcp/                    # MCP design system server
+    ├── src/
+    │   ├── server.ts       # Resources, prompts, tools
+    │   └── renderer.ts     # Theme CSS + bridge JS assembly
+    └── skills/             # Playbook .txt files
+        ├── master-agent-playbook.txt
+        ├── svg-diagram-skill.txt
+        └── agent-skills-vol2.txt`,
     },
     {
       type: "markdown",
       id: "intro-flow",
-      content: `## How it flows
+      content: `## The Visualization Flow
 
-1. User opens the app and sees a chat interface alongside a todo canvas
-2. User types a message (e.g., "Add 3 todos for a weekend trip")
-3. CopilotKit sends the message to the LangGraph agent
-4. The agent calls the \`manage_todos\` tool to update state
-5. State syncs back to the frontend via CopilotKit
-6. The todo list UI updates reactively
+Every visual response follows a **mandatory 4-step workflow**:
 
-Let's dive into how each piece works, starting with **Agent State**.`,
+1. **Acknowledge** — Agent replies with 1-2 sentences of context
+2. **Plan** — Agent calls \`plan_visualization\` (approach, technology, key elements)
+3. **Build** — Agent calls \`widgetRenderer\` / \`pieChart\` / \`barChart\`
+4. **Narrate** — Agent adds 2-3 sentences walking through the result
+
+The plan step is never skipped — it gives the user a preview of what's coming and helps the agent organize its approach.
+
+Let's dive into each layer, starting with the **Widget Renderer**.`,
     },
   ],
 };

--- a/apps/notebook/src/content/chapters/02-agent-state.ts
+++ b/apps/notebook/src/content/chapters/02-agent-state.ts
@@ -1,0 +1,187 @@
+import type { Chapter } from "@/lib/types";
+
+export const agentState: Chapter = {
+  id: "agent-state",
+  title: "Agent State",
+  description:
+    "The v2 pattern where state lives in the agent and syncs to the frontend.",
+  icon: "🔄",
+  cells: [
+    {
+      type: "markdown",
+      id: "state-concept",
+      content: `# Agent State Pattern
+
+CopilotKit v2 introduces a powerful pattern: **state lives in the agent backend**, not in the frontend. The frontend simply reads and writes to the agent's state, and CopilotKit handles the sync.
+
+This means:
+- The agent defines the **shape** of the state (a Python TypedDict)
+- The agent modifies state through **tools** (using LangGraph's \`Command(update={...})\`)
+- The frontend reads state via \`agent.state\` and writes via \`agent.setState()\`
+- Changes propagate **bidirectionally** — user edits sync to the agent, agent edits sync to the UI`,
+    },
+    {
+      type: "code",
+      id: "state-schema",
+      language: "python",
+      filename: "apps/agent/src/todos.py — State Schema",
+      content: `from typing import Literal, TypedDict
+
+class Todo(TypedDict):
+    id: str
+    title: str
+    description: str
+    emoji: str
+    status: Literal["pending", "completed"]
+
+class AgentState(TypedDict):
+    todos: list[Todo]`,
+    },
+    {
+      type: "markdown",
+      id: "state-tools-intro",
+      content: `## Agent Tools
+
+The agent manipulates state through LangGraph tools. The key tool is \`manage_todos\`, which receives a list of todos and returns a \`Command\` that updates the agent's state:`,
+    },
+    {
+      type: "code",
+      id: "state-manage-tool",
+      language: "python",
+      filename: "apps/agent/src/todos.py — manage_todos tool",
+      content: `import uuid
+from langchain_core.tools import tool
+from langchain_core.messages import ToolMessage
+from langgraph.types import Command
+
+@tool
+def manage_todos(todos: list[Todo], runtime) -> Command:
+    """Manage the current todos."""
+    # Ensure each todo has a unique ID
+    for todo in todos:
+        if "id" not in todo or not todo["id"]:
+            todo["id"] = str(uuid.uuid4())
+
+    return Command(update={
+        "todos": todos,
+        "messages": [ToolMessage(
+            content="Updated todos successfully.",
+            tool_call_id=runtime.tool_call_id,
+        )]
+    })`,
+    },
+    {
+      type: "markdown",
+      id: "state-frontend-intro",
+      content: `## Frontend Integration
+
+On the frontend, the \`useAgent()\` hook provides access to the agent's state. The Canvas component reads todos from the agent and sends updates back:`,
+    },
+    {
+      type: "code",
+      id: "state-frontend-code",
+      language: "tsx",
+      filename: "apps/app/src/components/canvas/index.tsx",
+      content: `import { useAgent } from "@copilotkit/react-core";
+
+export function Canvas() {
+  const { agent } = useAgent();
+
+  return (
+    <TodoList
+      todos={agent.state?.todos || []}
+      onUpdate={(updatedTodos) => agent.setState({ todos: updatedTodos })}
+      isAgentRunning={agent.isRunning}
+    />
+  );
+}`,
+    },
+    {
+      type: "playground",
+      id: "state-playground",
+      title: "Try it: State-driven Todo List",
+      files: {
+        "/App.js": `import { useState } from "react";
+
+const initialTodos = [
+  { id: "1", title: "Learn CopilotKit", emoji: "📚", status: "pending" },
+  { id: "2", title: "Build an agent", emoji: "🤖", status: "pending" },
+  { id: "3", title: "Ship it!", emoji: "🚀", status: "completed" },
+];
+
+export default function App() {
+  // In the real app, this state comes from agent.state.todos
+  const [todos, setTodos] = useState(initialTodos);
+
+  const toggle = (id) => {
+    setTodos(todos.map(t =>
+      t.id === id
+        ? { ...t, status: t.status === "completed" ? "pending" : "completed" }
+        : t
+    ));
+  };
+
+  const addTodo = () => {
+    setTodos([...todos, {
+      id: String(Date.now()),
+      title: "New todo",
+      emoji: "✨",
+      status: "pending",
+    }]);
+  };
+
+  const pending = todos.filter(t => t.status === "pending");
+  const completed = todos.filter(t => t.status === "completed");
+
+  return (
+    <div style={{ fontFamily: "'Plus Jakarta Sans', sans-serif", padding: 20 }}>
+      <h2 style={{ fontSize: 18, fontWeight: 700, marginBottom: 16 }}>
+        Agent State: Todos
+      </h2>
+      <div style={{ display: "flex", gap: 20 }}>
+        <Column title="To Do" todos={pending} onToggle={toggle} />
+        <Column title="Done" todos={completed} onToggle={toggle} />
+      </div>
+      <button
+        onClick={addTodo}
+        style={{
+          marginTop: 16, padding: "8px 16px", borderRadius: 8,
+          background: "#9599CC", color: "#fff", border: "none",
+          cursor: "pointer", fontWeight: 600, fontSize: 13,
+        }}
+      >
+        + Add Todo
+      </button>
+    </div>
+  );
+}
+
+function Column({ title, todos, onToggle }) {
+  return (
+    <div style={{ flex: 1 }}>
+      <h3 style={{ fontSize: 14, fontWeight: 600, color: "#6b7280", marginBottom: 8 }}>
+        {title} ({todos.length})
+      </h3>
+      {todos.map(t => (
+        <div
+          key={t.id}
+          onClick={() => onToggle(t.id)}
+          style={{
+            padding: "10px 12px", marginBottom: 8, borderRadius: 8,
+            background: t.status === "completed" ? "#f0fdf4" : "#fff",
+            border: "1px solid #e5e7eb", cursor: "pointer",
+            opacity: t.status === "completed" ? 0.7 : 1,
+            textDecoration: t.status === "completed" ? "line-through" : "none",
+            fontSize: 14,
+          }}
+        >
+          {t.emoji} {t.title}
+        </div>
+      ))}
+    </div>
+  );
+}`,
+      },
+    },
+  ],
+};

--- a/apps/notebook/src/content/chapters/02-agent-state.ts
+++ b/apps/notebook/src/content/chapters/02-agent-state.ts
@@ -1,183 +1,251 @@
 import type { Chapter } from "@/lib/types";
 
-export const agentState: Chapter = {
-  id: "agent-state",
-  title: "Agent State",
+export const widgetRenderer: Chapter = {
+  id: "widget-renderer",
+  title: "Widget Renderer",
   description:
-    "The v2 pattern where state lives in the agent and syncs to the frontend.",
-  icon: "🔄",
+    "The sandboxed iframe engine that renders agent-generated HTML, SVG, and 3D.",
+  icon: "🖼",
   cells: [
     {
       type: "markdown",
-      id: "state-concept",
-      content: `# Agent State Pattern
+      id: "wr-overview",
+      content: `# Widget Renderer
 
-CopilotKit v2 introduces a powerful pattern: **state lives in the agent backend**, not in the frontend. The frontend simply reads and writes to the agent's state, and CopilotKit handles the sync.
+The Widget Renderer is the core rendering engine. It takes arbitrary HTML from the agent and renders it in a **sandboxed iframe** with a full design system, streaming support, and a communication bridge.
 
-This means:
-- The agent defines the **shape** of the state (a Python TypedDict)
-- The agent modifies state through **tools** (using LangGraph's \`Command(update={...})\`)
-- The frontend reads state via \`agent.state\` and writes via \`agent.setState()\`
-- Changes propagate **bidirectionally** — user edits sync to the agent, agent edits sync to the UI`,
+## What gets injected into the iframe
+
+The iframe isn't just raw HTML. Before any agent content is inserted, the iframe shell is assembled with 6 layers:
+
+1. **Theme CSS** — Light/dark mode variables (\`--color-text-primary\`, \`--color-background-secondary\`, etc.)
+2. **SVG Classes** — Pre-built CSS classes for colored SVG elements (\`.c-purple\`, \`.c-teal\`, \`.c-blue\`)
+3. **Form Styles** — Native-looking buttons, inputs, sliders, checkboxes with animations
+4. **Bridge JS** — \`window.sendPrompt()\`, \`window.openLink()\`, auto-resize reporting
+5. **Import Map** — ES module aliases for Three.js, GSAP, D3, Chart.js from esm.sh
+6. **CSP Policy** — Restricts scripts to approved CDNs (cdnjs, esm.sh, jsdelivr, unpkg)`,
     },
     {
       type: "code",
-      id: "state-schema",
-      language: "python",
-      filename: "apps/agent/src/todos.py — State Schema",
-      content: `from typing import Literal, TypedDict
+      id: "wr-bridge",
+      language: "typescript",
+      filename: "Bridge JS (injected into every iframe)",
+      content: `// The bridge gives widgets 3 capabilities:
 
-class Todo(TypedDict):
-    id: str
-    title: str
-    description: str
-    emoji: str
-    status: Literal["pending", "completed"]
+// 1. Send a new prompt to the agent
+window.sendPrompt = (text: string) => {
+  window.parent.postMessage(
+    { type: "send-prompt", prompt: text },
+    "*"
+  );
+};
 
-class AgentState(TypedDict):
-    todos: list[Todo]`,
+// 2. Open external links (parent handles navigation)
+window.openLink = (url: string) => {
+  window.parent.postMessage(
+    { type: "open-link", url },
+    "*"
+  );
+};
+
+// 3. Auto-resize: report content height to parent
+// Content is cloned off-screen to prevent viewport inflation
+function reportHeight() {
+  const clone = document.body.cloneNode(true);
+  clone.style.cssText = "position:absolute;left:-9999px;width:" +
+    document.body.clientWidth + "px;visibility:hidden;";
+  document.documentElement.appendChild(clone);
+  const h = clone.scrollHeight;
+  clone.remove();
+  window.parent.postMessage({ type: "widget-resize", height: h }, "*");
+}
+
+new ResizeObserver(reportHeight).observe(document.body);`,
+    },
+    {
+      type: "code",
+      id: "wr-importmap",
+      language: "html",
+      filename: "Import Map (enables ES module imports in widgets)",
+      content: `<script type="importmap">
+{
+  "imports": {
+    "three": "https://esm.sh/three@0.170.0",
+    "three/addons/": "https://esm.sh/three@0.170.0/examples/jsm/",
+    "gsap": "https://esm.sh/gsap@3.12.7",
+    "d3": "https://esm.sh/d3@7.9.0",
+    "chart.js": "https://esm.sh/chart.js@4.4.7",
+    "chart.js/auto": "https://esm.sh/chart.js@4.4.7/auto"
+  }
+}
+</script>
+
+<!-- Widgets use these with <script type="module">:
+  import * as THREE from "three";
+  import { OrbitControls } from "three/addons/controls/OrbitControls.js";
+  import gsap from "gsap";
+  import * as d3 from "d3";
+-->`,
     },
     {
       type: "markdown",
-      id: "state-tools-intro",
-      content: `## Agent Tools
+      id: "wr-streaming",
+      content: `## Streaming with Idiomorph
 
-The agent manipulates state through LangGraph tools. The key tool is \`manage_todos\`, which receives a list of todos and returns a \`Command\` that updates the agent's state:`,
+When the agent streams HTML, the widget renderer uses **Idiomorph** for efficient DOM diffing. Instead of replacing the entire iframe on each chunk:
+
+1. Each HTML chunk arrives via \`postMessage({ type: 'update-content', html })\`
+2. \`<script>\` tags are **stripped before insertion** (prevents partial script execution)
+3. Idiomorph morphs the existing DOM to match new HTML (preserves state, animations, scroll)
+4. Scripts execute **sequentially** only when all tags are closed
+5. Module detection: if a script uses \`import\`/\`export\` but lacks \`type="module"\`, it's auto-promoted
+6. Scripts are deduped via base64 hash to prevent re-execution on morph cycles
+
+The iframe auto-resizes by reporting content height changes. Height is clamped between 50px and 4000px with an 800ms settling period before the streaming indicator disappears.`,
     },
     {
       type: "code",
-      id: "state-manage-tool",
-      language: "python",
-      filename: "apps/agent/src/todos.py — manage_todos tool",
-      content: `import uuid
-from langchain_core.tools import tool
-from langchain_core.messages import ToolMessage
-from langgraph.types import Command
-
-@tool
-def manage_todos(todos: list[Todo], runtime) -> Command:
-    """Manage the current todos."""
-    # Ensure each todo has a unique ID
-    for todo in todos:
-        if "id" not in todo or not todo["id"]:
-            todo["id"] = str(uuid.uuid4())
-
-    return Command(update={
-        "todos": todos,
-        "messages": [ToolMessage(
-            content="Updated todos successfully.",
-            tool_call_id=runtime.tool_call_id,
-        )]
-    })`,
-    },
-    {
-      type: "markdown",
-      id: "state-frontend-intro",
-      content: `## Frontend Integration
-
-On the frontend, the \`useAgent()\` hook provides access to the agent's state. The Canvas component reads todos from the agent and sends updates back:`,
-    },
-    {
-      type: "code",
-      id: "state-frontend-code",
+      id: "wr-react-component",
       language: "tsx",
-      filename: "apps/app/src/components/canvas/index.tsx",
-      content: `import { useAgent } from "@copilotkit/react-core";
+      filename: "widget-renderer.tsx — React component (simplified)",
+      content: `export function WidgetRenderer({ title, description, html }: WidgetProps) {
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const [height, setHeight] = useState(200);
+  const [htmlSettled, setHtmlSettled] = useState(false);
 
-export function Canvas() {
-  const { agent } = useAgent();
+  // Initialize empty iframe shell (prevents broken partial HTML)
+  useEffect(() => {
+    const iframe = iframeRef.current;
+    if (!iframe) return;
+    iframe.srcdoc = assembleShell(); // Theme CSS + Bridge JS + Import Map
+  }, []);
+
+  // Stream HTML updates via postMessage
+  useEffect(() => {
+    if (!html || !loaded) return;
+    iframe.contentWindow.postMessage(
+      { type: "update-content", html },
+      "*"
+    );
+  }, [html, loaded]);
+
+  // Listen for resize messages from iframe bridge
+  useEffect(() => {
+    const handler = (e: MessageEvent) => {
+      if (e.data?.type === "widget-resize") {
+        setHeight(Math.max(50, Math.min(4000, e.data.height)));
+      }
+    };
+    window.addEventListener("message", handler);
+    return () => window.removeEventListener("message", handler);
+  }, []);
 
   return (
-    <TodoList
-      todos={agent.state?.todos || []}
-      onUpdate={(updatedTodos) => agent.setState({ todos: updatedTodos })}
-      isAgentRunning={agent.isRunning}
-    />
+    <div>
+      <header>{title}</header>
+      <p>{description}</p>
+      {isStreaming && <StreamingIndicator />}
+      <iframe
+        ref={iframeRef}
+        sandbox="allow-scripts allow-same-origin"
+        style={{ height }}
+      />
+      {htmlSettled && <ExportOverlay />}
+    </div>
   );
 }`,
     },
     {
       type: "playground",
-      id: "state-playground",
-      title: "Try it: State-driven Todo List",
+      id: "wr-playground",
+      title: "Try it: Mini Widget Renderer",
       files: {
-        "/App.js": `import { useState } from "react";
+        "/App.js": `import { useState, useRef, useEffect } from "react";
 
-const initialTodos = [
-  { id: "1", title: "Learn CopilotKit", emoji: "📚", status: "pending" },
-  { id: "2", title: "Build an agent", emoji: "🤖", status: "pending" },
-  { id: "3", title: "Ship it!", emoji: "🚀", status: "completed" },
-];
+const defaultHTML = \`<div style="font-family: system-ui, sans-serif; padding: 24px;">
+  <h2 style="font-size: 20px; font-weight: 500;
+    color: var(--color-text-primary, #1a1a1a);">
+    Interactive Widget
+  </h2>
+  <p style="color: var(--color-text-secondary, #73726c); font-size: 14px;">
+    Edit this HTML — it renders in a sandboxed iframe, just like the real widget renderer.
+  </p>
+
+  <div id="boxes" style="display: flex; gap: 8px; margin-top: 16px;"></div>
+
+  <script>
+    const colors = ["#BEC2FF", "#85E0CE", "#9599CC", "#A8E9DC", "#D4D7FF"];
+    const container = document.getElementById("boxes");
+    colors.forEach((c, i) => {
+      const box = document.createElement("div");
+      box.style.cssText = \\\`
+        width: 50px; height: 50px; border-radius: 10px;
+        background: \\\${c}; cursor: pointer;
+        transition: transform 0.2s ease;
+      \\\`;
+      box.onmouseenter = () => box.style.transform = "scale(1.2) rotate(5deg)";
+      box.onmouseleave = () => box.style.transform = "scale(1)";
+      box.onclick = () => {
+        box.style.borderRadius = box.style.borderRadius === "50%" ? "10px" : "50%";
+      };
+      container.appendChild(box);
+    });
+  </script>
+</div>\`;
 
 export default function App() {
-  // In the real app, this state comes from agent.state.todos
-  const [todos, setTodos] = useState(initialTodos);
+  const [html, setHtml] = useState(defaultHTML);
+  const iframeRef = useRef(null);
 
-  const toggle = (id) => {
-    setTodos(todos.map(t =>
-      t.id === id
-        ? { ...t, status: t.status === "completed" ? "pending" : "completed" }
-        : t
-    ));
-  };
-
-  const addTodo = () => {
-    setTodos([...todos, {
-      id: String(Date.now()),
-      title: "New todo",
-      emoji: "✨",
-      status: "pending",
-    }]);
-  };
-
-  const pending = todos.filter(t => t.status === "pending");
-  const completed = todos.filter(t => t.status === "completed");
+  useEffect(() => {
+    if (!iframeRef.current) return;
+    const doc = iframeRef.current.contentDocument;
+    if (!doc) return;
+    doc.open();
+    doc.write(\`<!DOCTYPE html>
+<html><head>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+</head><body style="margin:0;background:transparent;">\${html}</body></html>\`);
+    doc.close();
+  }, [html]);
 
   return (
-    <div style={{ fontFamily: "'Plus Jakarta Sans', sans-serif", padding: 20 }}>
-      <h2 style={{ fontSize: 18, fontWeight: 700, marginBottom: 16 }}>
-        Agent State: Todos
-      </h2>
-      <div style={{ display: "flex", gap: 20 }}>
-        <Column title="To Do" todos={pending} onToggle={toggle} />
-        <Column title="Done" todos={completed} onToggle={toggle} />
-      </div>
-      <button
-        onClick={addTodo}
-        style={{
-          marginTop: 16, padding: "8px 16px", borderRadius: 8,
-          background: "#9599CC", color: "#fff", border: "none",
-          cursor: "pointer", fontWeight: 600, fontSize: 13,
-        }}
-      >
-        + Add Todo
-      </button>
-    </div>
-  );
-}
-
-function Column({ title, todos, onToggle }) {
-  return (
-    <div style={{ flex: 1 }}>
-      <h3 style={{ fontSize: 14, fontWeight: 600, color: "#6b7280", marginBottom: 8 }}>
-        {title} ({todos.length})
-      </h3>
-      {todos.map(t => (
-        <div
-          key={t.id}
-          onClick={() => onToggle(t.id)}
-          style={{
-            padding: "10px 12px", marginBottom: 8, borderRadius: 8,
-            background: t.status === "completed" ? "#f0fdf4" : "#fff",
-            border: "1px solid #e5e7eb", cursor: "pointer",
-            opacity: t.status === "completed" ? 0.7 : 1,
-            textDecoration: t.status === "completed" ? "line-through" : "none",
-            fontSize: 14,
-          }}
-        >
-          {t.emoji} {t.title}
+    <div style={{ fontFamily: "system-ui, sans-serif" }}>
+      <div style={{ display: "flex", flexDirection: "column" }}>
+        <div>
+          <div style={{
+            padding: "8px 12px", fontSize: 12, fontWeight: 600,
+            background: "#f9fafb", borderBottom: "1px solid #e5e7eb",
+            color: "#6b7280",
+          }}>
+            HTML (edit me)
+          </div>
+          <textarea
+            value={html}
+            onChange={(e) => setHtml(e.target.value)}
+            spellCheck={false}
+            style={{
+              width: "100%", height: 200, padding: 12, border: "none",
+              fontFamily: "'SF Mono', 'Fira Code', monospace", fontSize: 12,
+              lineHeight: 1.5, resize: "none", outline: "none", background: "#fff",
+            }}
+          />
         </div>
-      ))}
+        <div>
+          <div style={{
+            padding: "8px 12px", fontSize: 12, fontWeight: 600,
+            background: "#f9fafb", borderTop: "1px solid #e5e7eb",
+            borderBottom: "1px solid #e5e7eb", color: "#6b7280",
+          }}>
+            Sandboxed iframe preview
+          </div>
+          <iframe
+            ref={iframeRef}
+            sandbox="allow-scripts"
+            style={{ width: "100%", height: 200, border: "none", background: "#fff" }}
+          />
+        </div>
+      </div>
     </div>
   );
 }`,

--- a/apps/notebook/src/content/chapters/02-agent-state.ts
+++ b/apps/notebook/src/content/chapters/02-agent-state.ts
@@ -49,7 +49,6 @@ window.openLink = (url: string) => {
 };
 
 // 3. Auto-resize: report content height to parent
-// Content is cloned off-screen to prevent viewport inflation
 function reportHeight() {
   const clone = document.body.cloneNode(true);
   clone.style.cssText = "position:absolute;left:-9999px;width:" +
@@ -63,188 +62,272 @@ function reportHeight() {
 new ResizeObserver(reportHeight).observe(document.body);`,
     },
     {
-      type: "code",
-      id: "wr-importmap",
-      language: "html",
-      filename: "Import Map (enables ES module imports in widgets)",
-      content: `<script type="importmap">
-{
-  "imports": {
-    "three": "https://esm.sh/three@0.170.0",
-    "three/addons/": "https://esm.sh/three@0.170.0/examples/jsm/",
-    "gsap": "https://esm.sh/gsap@3.12.7",
-    "d3": "https://esm.sh/d3@7.9.0",
-    "chart.js": "https://esm.sh/chart.js@4.4.7",
-    "chart.js/auto": "https://esm.sh/chart.js@4.4.7/auto"
-  }
-}
-</script>
-
-<!-- Widgets use these with <script type="module">:
-  import * as THREE from "three";
-  import { OrbitControls } from "three/addons/controls/OrbitControls.js";
-  import gsap from "gsap";
-  import * as d3 from "d3";
--->`,
-    },
-    {
       type: "markdown",
       id: "wr-streaming",
       content: `## Streaming with Idiomorph
 
-When the agent streams HTML, the widget renderer uses **Idiomorph** for efficient DOM diffing. Instead of replacing the entire iframe on each chunk:
+When the agent streams HTML, the widget renderer uses **Idiomorph** for efficient DOM diffing. Instead of replacing the entire iframe on each chunk, Idiomorph morphs the existing DOM — preserving interactive state, animations, and scroll position.
 
-1. Each HTML chunk arrives via \`postMessage({ type: 'update-content', html })\`
-2. \`<script>\` tags are **stripped before insertion** (prevents partial script execution)
-3. Idiomorph morphs the existing DOM to match new HTML (preserves state, animations, scroll)
-4. Scripts execute **sequentially** only when all tags are closed
-5. Module detection: if a script uses \`import\`/\`export\` but lacks \`type="module"\`, it's auto-promoted
-6. Scripts are deduped via base64 hash to prevent re-execution on morph cycles
-
-The iframe auto-resizes by reporting content height changes. Height is clamped between 50px and 4000px with an 800ms settling period before the streaming indicator disappears.`,
+The playground below demonstrates this: watch the HTML stream in character-by-character (like an LLM producing tokens), while the iframe updates progressively without flickering.`,
     },
     {
-      type: "code",
-      id: "wr-react-component",
-      language: "tsx",
-      filename: "widget-renderer.tsx — React component (simplified)",
-      content: `export function WidgetRenderer({ title, description, html }: WidgetProps) {
-  const iframeRef = useRef<HTMLIFrameElement>(null);
-  const [height, setHeight] = useState(200);
-  const [htmlSettled, setHtmlSettled] = useState(false);
+      type: "playground",
+      id: "wr-streaming-playground",
+      title: "Live: Streaming HTML into an iframe",
+      files: {
+        "/App.js": `import { useState, useRef, useEffect, useCallback } from "react";
 
-  // Initialize empty iframe shell (prevents broken partial HTML)
-  useEffect(() => {
-    const iframe = iframeRef.current;
-    if (!iframe) return;
-    iframe.srcdoc = assembleShell(); // Theme CSS + Bridge JS + Import Map
-  }, []);
+// This is a real demo of how the widget renderer streams HTML.
+// The HTML arrives token-by-token (like an LLM), and the iframe
+// updates progressively — just like the real widget-renderer.tsx.
 
-  // Stream HTML updates via postMessage
-  useEffect(() => {
-    if (!html || !loaded) return;
-    iframe.contentWindow.postMessage(
-      { type: "update-content", html },
-      "*"
-    );
-  }, [html, loaded]);
+const FULL_HTML = \`<style>
+  body { font-family: system-ui, sans-serif; padding: 20px; margin: 0; }
+  .card { background: #f7f6f3; border: 0.5px solid rgba(0,0,0,0.15);
+    border-radius: 12px; padding: 16px; margin-bottom: 12px; }
+  .metric { display: flex; justify-content: space-between; align-items: baseline;
+    padding: 8px 0; border-bottom: 0.5px solid rgba(0,0,0,0.08); }
+  .metric:last-child { border: none; }
+  .label { font-size: 14px; color: #73726c; }
+  .value { font-size: 20px; font-weight: 500; color: #1a1a1a; }
+  .bar-row { display: flex; align-items: center; gap: 10px; margin: 6px 0; }
+  .bar-label { width: 80px; font-size: 12px; color: #73726c; text-align: right; }
+  .bar-track { flex: 1; height: 20px; background: #efeee9; border-radius: 6px; overflow: hidden; }
+  .bar-fill { height: 100%; border-radius: 6px; transition: width 0.8s ease; }
+  h2 { font-size: 18px; font-weight: 500; color: #1a1a1a; margin: 0 0 12px; }
+  h3 { font-size: 16px; font-weight: 500; color: #1a1a1a; margin: 0 0 8px; }
+</style>
+<h2>Agent Performance Dashboard</h2>
+<div class="card">
+  <h3>Key Metrics</h3>
+  <div class="metric"><span class="label">Tool calls</span><span class="value">1,247</span></div>
+  <div class="metric"><span class="label">Avg latency</span><span class="value">340ms</span></div>
+  <div class="metric"><span class="label">Success rate</span><span class="value">99.2%</span></div>
+  <div class="metric"><span class="label">Active threads</span><span class="value">42</span></div>
+</div>
+<div class="card">
+  <h3>Tool Usage</h3>
+  <div class="bar-row"><span class="bar-label">widgets</span><div class="bar-track"><div class="bar-fill" style="width:78%;background:#5B3FA0"></div></div><span style="font-size:12px;color:#73726c">78%</span></div>
+  <div class="bar-row"><span class="bar-label">charts</span><div class="bar-track"><div class="bar-fill" style="width:52%;background:#0F6E56"></div></div><span style="font-size:12px;color:#73726c">52%</span></div>
+  <div class="bar-row"><span class="bar-label">todos</span><div class="bar-track"><div class="bar-fill" style="width:35%;background:#2663B3"></div></div><span style="font-size:12px;color:#73726c">35%</span></div>
+  <div class="bar-row"><span class="bar-label">queries</span><div class="bar-track"><div class="bar-fill" style="width:20%;background:#C44D4D"></div></div><span style="font-size:12px;color:#73726c">20%</span></div>
+</div>\`;
 
-  // Listen for resize messages from iframe bridge
+export default function App() {
+  const [streamedHtml, setStreamedHtml] = useState("");
+  const [isStreaming, setIsStreaming] = useState(false);
+  const [charIndex, setCharIndex] = useState(0);
+  const [iframeHeight, setIframeHeight] = useState(60);
+  const iframeRef = useRef(null);
+  const intervalRef = useRef(null);
+
+  // Listen for resize messages from iframe (just like the real bridge)
   useEffect(() => {
-    const handler = (e: MessageEvent) => {
+    const handler = (e) => {
       if (e.data?.type === "widget-resize") {
-        setHeight(Math.max(50, Math.min(4000, e.data.height)));
+        setIframeHeight(Math.max(60, Math.min(800, e.data.height + 10)));
       }
     };
     window.addEventListener("message", handler);
     return () => window.removeEventListener("message", handler);
   }, []);
 
+  // Update iframe content as HTML streams in
+  useEffect(() => {
+    if (!iframeRef.current || !streamedHtml) return;
+    const doc = iframeRef.current.contentDocument;
+    if (!doc) return;
+    doc.open();
+    doc.write(\`<!DOCTYPE html><html><head></head><body style="margin:0">\${streamedHtml}
+      <script>
+        function reportHeight() {
+          window.parent.postMessage({ type: "widget-resize", height: document.body.scrollHeight }, "*");
+        }
+        new ResizeObserver(reportHeight).observe(document.body);
+        reportHeight();
+      </script>
+    </body></html>\`);
+    doc.close();
+  }, [streamedHtml]);
+
+  const startStream = useCallback(() => {
+    setStreamedHtml("");
+    setCharIndex(0);
+    setIsStreaming(true);
+    setIframeHeight(60);
+    let idx = 0;
+    clearInterval(intervalRef.current);
+    intervalRef.current = setInterval(() => {
+      // Stream ~8 chars at a time (simulating token chunks)
+      idx = Math.min(idx + 8, FULL_HTML.length);
+      setStreamedHtml(FULL_HTML.slice(0, idx));
+      setCharIndex(idx);
+      if (idx >= FULL_HTML.length) {
+        clearInterval(intervalRef.current);
+        setIsStreaming(false);
+      }
+    }, 16);
+  }, []);
+
+  useEffect(() => () => clearInterval(intervalRef.current), []);
+
+  const pct = FULL_HTML.length > 0 ? Math.round((charIndex / FULL_HTML.length) * 100) : 0;
+
   return (
-    <div>
-      <header>{title}</header>
-      <p>{description}</p>
-      {isStreaming && <StreamingIndicator />}
-      <iframe
-        ref={iframeRef}
-        sandbox="allow-scripts allow-same-origin"
-        style={{ height }}
-      />
-      {htmlSettled && <ExportOverlay />}
+    <div style={{ fontFamily: "system-ui, sans-serif" }}>
+      {/* Streaming progress bar */}
+      <div style={{ padding: "12px 16px", borderBottom: "1px solid #e5e7eb", display: "flex", alignItems: "center", gap: 12 }}>
+        <button onClick={startStream} disabled={isStreaming} style={{
+          padding: "6px 14px", borderRadius: 8, border: "none",
+          background: isStreaming ? "#e5e7eb" : "#5B3FA0", color: isStreaming ? "#9ca3af" : "#fff",
+          cursor: isStreaming ? "default" : "pointer", fontWeight: 600, fontSize: 13, whiteSpace: "nowrap",
+        }}>
+          {isStreaming ? "Streaming..." : "Stream HTML"}
+        </button>
+        <div style={{ flex: 1, height: 6, background: "#efeee9", borderRadius: 3, overflow: "hidden" }}>
+          <div style={{ width: pct + "%", height: "100%", background: "linear-gradient(90deg, #5B3FA0, #0F6E56)", borderRadius: 3, transition: "width 0.05s linear" }} />
+        </div>
+        <span style={{ fontSize: 11, color: "#73726c", fontFamily: "monospace", minWidth: 60, textAlign: "right" }}>
+          {charIndex}/{FULL_HTML.length}
+        </span>
+      </div>
+
+      {/* Live iframe preview — auto-resizes via bridge postMessage */}
+      <div style={{ background: "#fff" }}>
+        {!streamedHtml && !isStreaming ? (
+          <div style={{ padding: 40, textAlign: "center", color: "#9ca3af", fontSize: 14 }}>
+            Click "Stream HTML" to watch the widget render progressively
+          </div>
+        ) : (
+          <iframe
+            ref={iframeRef}
+            sandbox="allow-scripts allow-same-origin"
+            style={{ width: "100%", height: iframeHeight, border: "none", display: "block", transition: "height 0.3s ease" }}
+          />
+        )}
+      </div>
     </div>
   );
 }`,
+      },
     },
     {
       type: "playground",
-      id: "wr-playground",
-      title: "Try it: Mini Widget Renderer",
+      id: "wr-bridge-playground",
+      title: "Live: Bridge communication (sendPrompt + auto-resize)",
       files: {
         "/App.js": `import { useState, useRef, useEffect } from "react";
 
-const defaultHTML = \`<div style="font-family: system-ui, sans-serif; padding: 24px;">
-  <h2 style="font-size: 20px; font-weight: 500;
-    color: var(--color-text-primary, #1a1a1a);">
-    Interactive Widget
-  </h2>
-  <p style="color: var(--color-text-secondary, #73726c); font-size: 14px;">
-    Edit this HTML — it renders in a sandboxed iframe, just like the real widget renderer.
-  </p>
+// This demonstrates the real bridge: the iframe sends messages
+// to the parent via postMessage, and the parent listens.
 
-  <div id="boxes" style="display: flex; gap: 8px; margin-top: 16px;"></div>
-
-  <script>
-    const colors = ["#BEC2FF", "#85E0CE", "#9599CC", "#A8E9DC", "#D4D7FF"];
-    const container = document.getElementById("boxes");
-    colors.forEach((c, i) => {
-      const box = document.createElement("div");
-      box.style.cssText = \\\`
-        width: 50px; height: 50px; border-radius: 10px;
-        background: \\\${c}; cursor: pointer;
-        transition: transform 0.2s ease;
-      \\\`;
-      box.onmouseenter = () => box.style.transform = "scale(1.2) rotate(5deg)";
-      box.onmouseleave = () => box.style.transform = "scale(1)";
-      box.onclick = () => {
-        box.style.borderRadius = box.style.borderRadius === "50%" ? "10px" : "50%";
-      };
-      container.appendChild(box);
-    });
-  </script>
-</div>\`;
+const WIDGET_HTML = \`
+<style>
+  body { font-family: system-ui, sans-serif; padding: 16px; margin: 0; }
+  .prompt-btn { padding: 8px 16px; border-radius: 8px; border: none;
+    background: #5B3FA0; color: #fff; font-weight: 500; cursor: pointer;
+    font-size: 13px; margin: 4px; transition: transform 0.15s; }
+  .prompt-btn:hover { transform: scale(1.03); }
+  .expander { margin-top: 12px; }
+  .toggle-btn { padding: 6px 12px; border-radius: 6px; border: 0.5px solid rgba(0,0,0,0.15);
+    background: #f7f6f3; cursor: pointer; font-size: 12px; color: #73726c; }
+  .extra { margin-top: 8px; padding: 12px; background: #f7f6f3; border-radius: 8px;
+    font-size: 13px; color: #73726c; display: none; }
+  .extra.open { display: block; }
+</style>
+<h3 style="font-size:16px;font-weight:500;margin:0 0 8px">Bridge Demo Widget</h3>
+<p style="font-size:13px;color:#73726c;margin:0 0 12px">
+  These buttons call <code>window.sendPrompt()</code> — the parent catches the message.
+</p>
+<div>
+  <button class="prompt-btn" onclick="window.parent.postMessage({type:'send-prompt',prompt:'Show me a bar chart of quarterly revenue'},'*')">
+    Ask for a chart
+  </button>
+  <button class="prompt-btn" onclick="window.parent.postMessage({type:'send-prompt',prompt:'Add 3 todos for a product launch'},'*')">
+    Ask for todos
+  </button>
+  <button class="prompt-btn" onclick="window.parent.postMessage({type:'send-prompt',prompt:'Explain the widget renderer architecture'},'*')">
+    Ask to explain
+  </button>
+</div>
+<div class="expander">
+  <button class="toggle-btn" onclick="
+    var el = document.getElementById('extra');
+    el.classList.toggle('open');
+    window.parent.postMessage({type:'widget-resize', height: document.body.scrollHeight}, '*');
+  ">Toggle more content (triggers auto-resize)</button>
+  <div id="extra" class="extra">
+    This extra content changes the iframe height. The bridge reports the new height
+    to the parent via <code>postMessage({type:'widget-resize'})</code>, and the
+    parent adjusts the iframe size — no fixed heights needed.
+  </div>
+</div>
+\`;
 
 export default function App() {
-  const [html, setHtml] = useState(defaultHTML);
   const iframeRef = useRef(null);
+  const [height, setHeight] = useState(180);
+  const [messages, setMessages] = useState([]);
+
+  useEffect(() => {
+    const handler = (e) => {
+      if (e.data?.type === "widget-resize") {
+        setHeight(Math.max(80, e.data.height + 10));
+      }
+      if (e.data?.type === "send-prompt") {
+        setMessages(prev => [...prev, { text: e.data.prompt, time: new Date().toLocaleTimeString() }]);
+      }
+    };
+    window.addEventListener("message", handler);
+    return () => window.removeEventListener("message", handler);
+  }, []);
 
   useEffect(() => {
     if (!iframeRef.current) return;
     const doc = iframeRef.current.contentDocument;
     if (!doc) return;
     doc.open();
-    doc.write(\`<!DOCTYPE html>
-<html><head>
-<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
-</head><body style="margin:0;background:transparent;">\${html}</body></html>\`);
+    doc.write(\`<!DOCTYPE html><html><body style="margin:0">\${WIDGET_HTML}
+      <script>
+        new ResizeObserver(() => {
+          window.parent.postMessage({type:'widget-resize', height: document.body.scrollHeight}, '*');
+        }).observe(document.body);
+      </script>
+    </body></html>\`);
     doc.close();
-  }, [html]);
+  }, []);
 
   return (
     <div style={{ fontFamily: "system-ui, sans-serif" }}>
-      <div style={{ display: "flex", flexDirection: "column" }}>
-        <div>
-          <div style={{
-            padding: "8px 12px", fontSize: 12, fontWeight: 600,
-            background: "#f9fafb", borderBottom: "1px solid #e5e7eb",
-            color: "#6b7280",
-          }}>
-            HTML (edit me)
-          </div>
-          <textarea
-            value={html}
-            onChange={(e) => setHtml(e.target.value)}
-            spellCheck={false}
-            style={{
-              width: "100%", height: 200, padding: 12, border: "none",
-              fontFamily: "'SF Mono', 'Fira Code', monospace", fontSize: 12,
-              lineHeight: 1.5, resize: "none", outline: "none", background: "#fff",
-            }}
-          />
+      {/* The widget iframe */}
+      <iframe
+        ref={iframeRef}
+        sandbox="allow-scripts allow-same-origin"
+        style={{ width: "100%", height, border: "none", display: "block",
+          transition: "height 0.3s ease", borderBottom: "1px solid #e5e7eb" }}
+      />
+
+      {/* Parent message log — shows what the bridge sent */}
+      <div style={{ padding: 12, background: "#f9fafb", minHeight: 60 }}>
+        <div style={{ fontSize: 11, fontWeight: 600, color: "#6b7280", marginBottom: 6, textTransform: "uppercase", letterSpacing: "0.05em" }}>
+          Parent received via postMessage:
         </div>
-        <div>
-          <div style={{
-            padding: "8px 12px", fontSize: 12, fontWeight: 600,
-            background: "#f9fafb", borderTop: "1px solid #e5e7eb",
-            borderBottom: "1px solid #e5e7eb", color: "#6b7280",
-          }}>
-            Sandboxed iframe preview
+        {messages.length === 0 ? (
+          <div style={{ fontSize: 12, color: "#9ca3af", fontStyle: "italic" }}>
+            Click a button inside the widget above...
           </div>
-          <iframe
-            ref={iframeRef}
-            sandbox="allow-scripts"
-            style={{ width: "100%", height: 200, border: "none", background: "#fff" }}
-          />
-        </div>
+        ) : (
+          messages.map((m, i) => (
+            <div key={i} style={{
+              padding: "6px 10px", marginBottom: 4, borderRadius: 6,
+              background: "#fff", border: "1px solid #e5e7eb", fontSize: 12,
+              display: "flex", justifyContent: "space-between",
+            }}>
+              <span><strong style={{color:"#5B3FA0"}}>sendPrompt:</strong> {m.text}</span>
+              <span style={{ color: "#9ca3af", fontSize: 10 }}>{m.time}</span>
+            </div>
+          ))
+        )}
       </div>
     </div>
   );

--- a/apps/notebook/src/content/chapters/03-generative-ui.ts
+++ b/apps/notebook/src/content/chapters/03-generative-ui.ts
@@ -25,10 +25,8 @@ The key insight: CopilotKit lets you register **React components as agent tools*
       id: "ck-runtime",
       language: "typescript",
       filename: "apps/app/src/app/api/copilotkit/route.ts",
-      content: `import { CopilotRuntime } from "@copilotkit/runtime";
-import { LangGraphHttpAgent } from "@copilotkit/runtime";
+      content: `import { CopilotRuntime, LangGraphHttpAgent } from "@copilotkit/runtime";
 
-// Connect to the LangGraph agent backend
 const defaultAgent = new LangGraphHttpAgent({
   deploymentUrl: process.env.LANGGRAPH_DEPLOYMENT_URL || "http://localhost:8123",
   agentName: "sample_agent",
@@ -36,11 +34,7 @@ const defaultAgent = new LangGraphHttpAgent({
 
 const runtime = new CopilotRuntime({
   agents: { default: defaultAgent },
-
-  // Auto-inject A2UI (Agent-to-UI) tool
   a2ui: { injectA2UITool: true },
-
-  // Optional: connect MCP server for skills
   mcpApps: {
     servers: process.env.MCP_SERVER_URL ? [{
       type: "http",
@@ -65,202 +59,275 @@ All CopilotKit hooks are registered in a single custom hook. Here's the full set
 | \`useFrontendTool()\` | \`toggleTheme\` | Agent can switch light/dark mode |
 | \`useRenderTool()\` | \`plan_visualization\` | Shows PlanCard while agent plans |
 | \`useHumanInTheLoop()\` | \`scheduleTime\` | Pauses for user to pick a meeting time |
-| \`useDefaultRenderTool()\` | (all tools) | Shows reasoning indicator for any tool |`,
-    },
-    {
-      type: "code",
-      id: "ck-hooks-code",
-      language: "tsx",
-      filename: "apps/app/src/hooks/use-generative-ui-examples.tsx",
-      content: `import { useComponent, useFrontendTool, useRenderTool,
-         useDefaultRenderTool, useHumanInTheLoop } from "@copilotkit/react-core";
 
-export function useGenerativeUIExamples() {
-  // 1. Component tools — agent renders these in the chat stream
-  useComponent("pieChart", {
-    component: PieChart,
-    schema: PieChartProps,  // Zod schema → agent sees as tool params
-    description: "Render a pie chart with labeled data segments",
-  });
-
-  useComponent("widgetRenderer", {
-    component: WidgetRenderer,
-    schema: z.object({
-      title: z.string(),
-      description: z.string(),
-      html: z.string().describe("Self-contained HTML with inline styles and scripts"),
-    }),
-    description: "Render interactive HTML/SVG/3D visualizations in a sandboxed iframe",
-  });
-
-  // 2. Frontend tool — agent calls JS in the browser (no UI)
-  const { setTheme } = useTheme();
-  useFrontendTool("toggleTheme", {
-    description: "Toggle between light and dark mode",
-    schema: z.object({}),
-    handler: () => {
-      setTheme(currentTheme === "dark" ? "light" : "dark");
-      return "Theme toggled";
-    },
-  });
-
-  // 3. Render tool — runs logic AND shows UI during execution
-  useRenderTool("plan_visualization", {
-    description: "Show planning progress before building a visualization",
-    schema: z.object({
-      status: z.string(),
-      approach: z.string(),
-      technology: z.string(),
-      keyElements: z.array(z.string()),
-    }),
-    component: PlanCard,  // Shows while the tool executes
-    handler: (props) => \`Plan: \${props.approach}\`,
-  });
-
-  // 4. Human-in-the-loop — pauses agent, waits for user input
-  useHumanInTheLoop("scheduleTime", {
-    description: "Schedule a meeting time with the user",
-    schema: z.object({
-      reasonForScheduling: z.string(),
-      meetingDuration: z.string(),
-    }),
-    component: MeetingTimePicker,  // User picks a time, then agent resumes
-  });
-
-  // 5. Default render tool — shows reasoning for ALL tool calls
-  useDefaultRenderTool({
-    component: ToolReasoning,
-    excludeTools: ["generate_form"],
-  });
-}`,
-    },
-    {
-      type: "markdown",
-      id: "ck-useagent",
-      content: `## useAgent() — Reading and Writing Agent State
-
-The \`useAgent()\` hook gives the frontend direct access to the agent's state. In OpenGenerativeUI, this powers the todo canvas:
-
-- \`agent.state.todos\` — Read the current todo list
-- \`agent.setState({ todos: [...] })\` — Update from the frontend
-- \`agent.isRunning\` — Shows loading state while agent processes
-
-Both user edits and agent tool calls modify the same state. CopilotKit handles the bidirectional sync automatically.`,
-    },
-    {
-      type: "code",
-      id: "ck-canvas",
-      language: "tsx",
-      filename: "apps/app/src/components/canvas/index.tsx",
-      content: `import { useAgent } from "@copilotkit/react-core";
-
-export function Canvas() {
-  const { agent } = useAgent();
-
-  return (
-    <TodoList
-      // Read from agent state
-      todos={agent.state?.todos || []}
-      // Write to agent state (syncs to backend)
-      onUpdate={(updated) => agent.setState({ todos: updated })}
-      // React to agent activity
-      isAgentRunning={agent.isRunning}
-    />
-  );
-}`,
+The playground below is a working simulation of these hooks — the "agent" picks tools, and the corresponding React components render live in a chat-like stream:`,
     },
     {
       type: "playground",
-      id: "ck-playground",
-      title: "Try it: Component Tool Registration",
+      id: "ck-hooks-playground",
+      title: "Live: Agent calls component tools, React renders them",
+      dependencies: { recharts: "2.12.7" },
       files: {
-        "/App.js": `import { useState } from "react";
+        "/App.js": `import { useState, useEffect, useRef } from "react";
+import { PieChart, Pie, Cell, ResponsiveContainer, BarChart, Bar, XAxis, YAxis, Tooltip } from "recharts";
 
-// Simulating how useComponent() works:
-// The agent calls "renderCard" with props → CopilotKit renders the component
-
-function AgentCard({ title, items, color }) {
-  return (
-    <div style={{
-      padding: 16, borderRadius: 12, fontFamily: "system-ui, sans-serif",
-      background: color === "mint" ? "#f0fdf4" : "#f5f3ff",
-      border: \`1px solid \${color === "mint" ? "#a7f3d0" : "#c4b5fd"}\`,
-    }}>
-      <h3 style={{ fontSize: 15, fontWeight: 600, margin: "0 0 8px 0" }}>{title}</h3>
-      <ul style={{ margin: 0, paddingLeft: 20, fontSize: 13, lineHeight: 1.8 }}>
-        {items.map((item, i) => <li key={i}>{item}</li>)}
-      </ul>
+// Registered component tools — same concept as useComponent()
+const componentTools = {
+  pieChart: ({ title, data }) => (
+    <div style={{ background: "#fff", borderRadius: 12, border: "1px solid #e5e7eb", padding: 16 }}>
+      <h3 style={{ fontSize: 15, fontWeight: 600, margin: "0 0 4px" }}>{title}</h3>
+      <ResponsiveContainer width="100%" height={180}>
+        <PieChart><Pie data={data} dataKey="value" nameKey="label" cx="50%" cy="50%" outerRadius={70} strokeWidth={2}>
+          {data.map((_, i) => <Cell key={i} fill={["#5B3FA0","#0F6E56","#2663B3","#C44D4D","#B8860B"][i % 5]} />)}
+        </Pie></PieChart>
+      </ResponsiveContainer>
+      <div style={{ display: "flex", gap: 12, justifyContent: "center", flexWrap: "wrap" }}>
+        {data.map((d, i) => (
+          <span key={i} style={{ fontSize: 11, display: "flex", alignItems: "center", gap: 4 }}>
+            <span style={{ width: 8, height: 8, borderRadius: 2, background: ["#5B3FA0","#0F6E56","#2663B3","#C44D4D","#B8860B"][i % 5] }} />
+            {d.label}: {d.value}
+          </span>
+        ))}
+      </div>
     </div>
-  );
-}
+  ),
+  barChart: ({ title, data }) => (
+    <div style={{ background: "#fff", borderRadius: 12, border: "1px solid #e5e7eb", padding: 16 }}>
+      <h3 style={{ fontSize: 15, fontWeight: 600, margin: "0 0 8px" }}>{title}</h3>
+      <ResponsiveContainer width="100%" height={180}>
+        <BarChart data={data}><XAxis dataKey="label" tick={{fontSize: 11}} /><YAxis tick={{fontSize: 11}} />
+          <Tooltip /><Bar dataKey="value" radius={[4,4,0,0]}>
+            {data.map((_, i) => <Cell key={i} fill={["#5B3FA0","#0F6E56","#2663B3","#C44D4D"][i % 4]} />)}
+          </Bar>
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  ),
+  widgetRenderer: ({ title, html }) => (
+    <div style={{ background: "#fff", borderRadius: 12, border: "1px solid #e5e7eb", overflow: "hidden" }}>
+      <div style={{ padding: "8px 12px", fontSize: 13, fontWeight: 600, borderBottom: "1px solid #e5e7eb" }}>{title}</div>
+      <div dangerouslySetInnerHTML={{ __html: html }} style={{ padding: 16 }} />
+    </div>
+  ),
+};
 
-// Simulated tool calls from the agent
-const toolCalls = [
+// Simulated agent tool calls with real data
+const agentActions = [
+  { type: "text", content: "Let me show you the project stats." },
   {
-    name: "renderCard",
-    args: {
-      title: "Frontend Stack",
-      items: ["Next.js 16 with Turbopack", "React 19", "TailwindCSS 4", "CopilotKit v2 hooks"],
-      color: "lilac",
+    type: "tool", tool: "pieChart", args: {
+      title: "Languages in Codebase",
+      data: [{ label: "TypeScript", value: 45 }, { label: "Python", value: 30 }, { label: "CSS", value: 15 }, { label: "Other", value: 10 }],
     },
   },
+  { type: "text", content: "And here's the weekly activity:" },
   {
-    name: "renderCard",
-    args: {
-      title: "Agent Stack",
-      items: ["LangGraph (Python)", "create_deep_agent", "CopilotKitMiddleware", "BoundedMemorySaver"],
-      color: "mint",
+    type: "tool", tool: "barChart", args: {
+      title: "Commits This Week",
+      data: [{ label: "Mon", value: 12 }, { label: "Tue", value: 8 }, { label: "Wed", value: 15 }, { label: "Thu", value: 6 }, { label: "Fri", value: 19 }],
+    },
+  },
+  { type: "text", content: "I can also render arbitrary HTML via the widget renderer:" },
+  {
+    type: "tool", tool: "widgetRenderer", args: {
+      title: "Status Indicators",
+      html: '<div style="display:flex;gap:12px;font-family:system-ui"><div style="padding:12px 16px;border-radius:8px;background:#EAF3DE;border:0.5px solid rgba(0,0,0,0.1)"><div style="font-size:11px;color:#3B6D11">Uptime</div><div style="font-size:22px;font-weight:500;color:#3B6D11">99.9%</div></div><div style="padding:12px 16px;border-radius:8px;background:#E6F1FB;border:0.5px solid rgba(0,0,0,0.1)"><div style="font-size:11px;color:#185FA5">Latency</div><div style="font-size:22px;font-weight:500;color:#185FA5">42ms</div></div><div style="padding:12px 16px;border-radius:8px;background:#FAEEDA;border:0.5px solid rgba(0,0,0,0.1)"><div style="font-size:11px;color:#854F0B">Queue</div><div style="font-size:22px;font-weight:500;color:#854F0B">7</div></div></div>',
     },
   },
 ];
 
 export default function App() {
-  const [rendered, setRendered] = useState([]);
-  const [calling, setCalling] = useState(false);
+  const [messages, setMessages] = useState([]);
+  const [running, setRunning] = useState(false);
+  const bottomRef = useRef(null);
 
-  const simulateAgent = async () => {
-    setCalling(true);
-    for (const call of toolCalls) {
-      await new Promise(r => setTimeout(r, 800));
-      setRendered(prev => [...prev, call]);
+  useEffect(() => { bottomRef.current?.scrollIntoView({ behavior: "smooth" }); }, [messages]);
+
+  const run = async () => {
+    setMessages([]);
+    setRunning(true);
+    for (const action of agentActions) {
+      await new Promise(r => setTimeout(r, 900));
+      setMessages(prev => [...prev, action]);
     }
-    setCalling(false);
+    setRunning(false);
   };
 
   return (
-    <div style={{ fontFamily: "system-ui, sans-serif", padding: 20 }}>
-      <h2 style={{ fontSize: 16, fontWeight: 700, marginBottom: 12 }}>
-        useComponent() Simulation
-      </h2>
-      <p style={{ fontSize: 13, color: "#6b7280", marginBottom: 16 }}>
-        When the agent calls a component tool, CopilotKit renders the React component inline:
-      </p>
-
-      <div style={{ display: "flex", flexDirection: "column", gap: 12, marginBottom: 16 }}>
-        {rendered.map((call, i) => (
+    <div style={{ fontFamily: "system-ui, sans-serif", display: "flex", flexDirection: "column", height: 480 }}>
+      {/* Chat stream */}
+      <div style={{ flex: 1, overflow: "auto", padding: 16, display: "flex", flexDirection: "column", gap: 10 }}>
+        {messages.length === 0 && !running && (
+          <div style={{ textAlign: "center", color: "#9ca3af", marginTop: 40, fontSize: 14 }}>
+            Click "Run Agent" to see component tools render live
+          </div>
+        )}
+        {messages.map((msg, i) => (
           <div key={i}>
-            <div style={{
-              fontSize: 11, fontFamily: "monospace", color: "#9599CC",
-              marginBottom: 4,
-            }}>
-              agent calls: {call.name}({JSON.stringify(call.args).slice(0, 60)}...)
-            </div>
-            <AgentCard {...call.args} />
+            {msg.type === "text" ? (
+              <div style={{ padding: "8px 12px", borderRadius: 8, background: "#f9fafb", fontSize: 14, color: "#374151", maxWidth: "85%" }}>
+                {msg.content}
+              </div>
+            ) : (
+              <div>
+                <div style={{ fontSize: 10, fontFamily: "monospace", color: "#5B3FA0", marginBottom: 4 }}>
+                  useComponent("{msg.tool}") renders:
+                </div>
+                {componentTools[msg.tool](msg.args)}
+              </div>
+            )}
           </div>
         ))}
+        {running && (
+          <div style={{ fontSize: 13, color: "#5B3FA0", display: "flex", alignItems: "center", gap: 6 }}>
+            <span style={{ width: 6, height: 6, borderRadius: "50%", background: "#5B3FA0", animation: "pulse 1s infinite" }} />
+            Agent is thinking...
+          </div>
+        )}
+        <div ref={bottomRef} />
+      </div>
+      <style>{"@keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.3; } }"}</style>
+
+      {/* Controls */}
+      <div style={{ padding: 12, borderTop: "1px solid #e5e7eb", display: "flex", gap: 8 }}>
+        <button onClick={run} disabled={running} style={{
+          flex: 1, padding: "10px", borderRadius: 8, border: "none",
+          background: running ? "#e5e7eb" : "#5B3FA0", color: running ? "#9ca3af" : "#fff",
+          cursor: running ? "default" : "pointer", fontWeight: 600, fontSize: 14,
+        }}>
+          {running ? "Running..." : "Run Agent"}
+        </button>
+      </div>
+    </div>
+  );
+}`,
+      },
+    },
+    {
+      type: "markdown",
+      id: "ck-state-sync",
+      content: `## useAgent() — Bidirectional State Sync
+
+The \`useAgent()\` hook gives the frontend direct access to the agent's state. Both user and agent can modify the same state:`,
+    },
+    {
+      type: "playground",
+      id: "ck-state-playground",
+      title: "Live: Bidirectional state sync (user + agent modify same todos)",
+      files: {
+        "/App.js": `import { useState, useCallback } from "react";
+
+// Simulates useAgent() — both sides write to the same state
+export default function App() {
+  const [todos, setTodos] = useState([
+    { id: "1", title: "Set up CopilotKit provider", emoji: "🔌", status: "completed" },
+    { id: "2", title: "Register component tools", emoji: "🪝", status: "completed" },
+    { id: "3", title: "Write agent system prompt", emoji: "📝", status: "pending" },
+  ]);
+  const [isAgentRunning, setIsAgentRunning] = useState(false);
+  const [lastAction, setLastAction] = useState("");
+
+  // User action: toggle todo status
+  const userToggle = (id) => {
+    setTodos(prev => prev.map(t => t.id === id ? { ...t, status: t.status === "completed" ? "pending" : "completed" } : t));
+    setLastAction("user: agent.setState({ todos: [...] })");
+  };
+
+  // User action: add todo
+  const userAdd = () => {
+    const newTodo = { id: String(Date.now()), title: "User-created task", emoji: "👤", status: "pending" };
+    setTodos(prev => [...prev, newTodo]);
+    setLastAction("user: agent.setState({ todos: [...todos, newTodo] })");
+  };
+
+  // Agent action: adds organized todos via manage_todos tool
+  const agentAction = useCallback(async () => {
+    setIsAgentRunning(true);
+    setLastAction("agent: calling manage_todos tool...");
+    await new Promise(r => setTimeout(r, 600));
+    setLastAction("agent: plan_visualization → approach: 'organize by priority'");
+    await new Promise(r => setTimeout(r, 800));
+
+    setTodos(prev => {
+      const organized = [
+        ...prev.filter(t => t.status === "pending"),
+        { id: String(Date.now()), title: "Deploy to production", emoji: "🚀", status: "pending" },
+        { id: String(Date.now()+1), title: "Write skill playbook", emoji: "📜", status: "pending" },
+        ...prev.filter(t => t.status === "completed"),
+      ];
+      return organized;
+    });
+    setLastAction("agent: Command(update={ todos: [...sorted, ...newTodos] })");
+    setIsAgentRunning(false);
+  }, []);
+
+  const pending = todos.filter(t => t.status === "pending");
+  const done = todos.filter(t => t.status === "completed");
+
+  return (
+    <div style={{ fontFamily: "system-ui, sans-serif", padding: 16 }}>
+      {/* State sync indicator */}
+      <div style={{
+        padding: "6px 12px", borderRadius: 8, fontSize: 11, fontFamily: "monospace",
+        background: lastAction.startsWith("agent") ? "#E3EFFC" : lastAction.startsWith("user") ? "#EAF3DE" : "#f9fafb",
+        color: lastAction.startsWith("agent") ? "#1A4680" : lastAction.startsWith("user") ? "#3B6D11" : "#9ca3af",
+        marginBottom: 12, transition: "all 0.3s",
+      }}>
+        {lastAction || "State: idle — try clicking a todo or running the agent"}
       </div>
 
-      <button
-        onClick={simulateAgent}
-        disabled={calling}
-        style={{
-          padding: "8px 16px", borderRadius: 8, border: "none",
-          background: calling ? "#d1d5db" : "#9599CC", color: "#fff",
-          cursor: calling ? "default" : "pointer", fontWeight: 600, fontSize: 13,
-        }}
-      >
-        {calling ? "Agent rendering..." : "Simulate Agent Tool Calls"}
-      </button>
+      <div style={{ display: "flex", gap: 16, marginBottom: 16 }}>
+        {/* Pending column */}
+        <div style={{ flex: 1 }}>
+          <div style={{ fontSize: 13, fontWeight: 600, color: "#6b7280", marginBottom: 8 }}>
+            Pending ({pending.length})
+          </div>
+          {pending.map(t => (
+            <div key={t.id} onClick={() => userToggle(t.id)} style={{
+              padding: "8px 12px", marginBottom: 6, borderRadius: 8, cursor: "pointer",
+              background: "#fff", border: "1px solid #e5e7eb", fontSize: 13,
+              transition: "transform 0.15s", display: "flex", alignItems: "center", gap: 6,
+            }}>
+              <span style={{ width: 16, height: 16, borderRadius: 4, border: "1.5px solid #d1d5db", flexShrink: 0 }} />
+              <span>{t.emoji} {t.title}</span>
+            </div>
+          ))}
+        </div>
+        {/* Done column */}
+        <div style={{ flex: 1 }}>
+          <div style={{ fontSize: 13, fontWeight: 600, color: "#6b7280", marginBottom: 8 }}>
+            Done ({done.length})
+          </div>
+          {done.map(t => (
+            <div key={t.id} onClick={() => userToggle(t.id)} style={{
+              padding: "8px 12px", marginBottom: 6, borderRadius: 8, cursor: "pointer",
+              background: "#f0fdf4", border: "1px solid #d1fae5", fontSize: 13, opacity: 0.8,
+              textDecoration: "line-through", display: "flex", alignItems: "center", gap: 6,
+            }}>
+              <span style={{ width: 16, height: 16, borderRadius: 4, background: "#0F6E56", flexShrink: 0, display: "flex", alignItems: "center", justifyContent: "center" }}>
+                <svg width="10" height="10" viewBox="0 0 12 12"><path d="M2 6l3 3 5-5" fill="none" stroke="#fff" strokeWidth="2"/></svg>
+              </span>
+              <span>{t.emoji} {t.title}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div style={{ display: "flex", gap: 8 }}>
+        <button onClick={userAdd} style={{
+          padding: "8px 14px", borderRadius: 8, border: "1px solid #d1d5db",
+          background: "#fff", cursor: "pointer", fontWeight: 600, fontSize: 12, color: "#374151",
+        }}>
+          + User adds todo
+        </button>
+        <button onClick={agentAction} disabled={isAgentRunning} style={{
+          padding: "8px 14px", borderRadius: 8, border: "none",
+          background: isAgentRunning ? "#e5e7eb" : "#5B3FA0", color: isAgentRunning ? "#9ca3af" : "#fff",
+          cursor: isAgentRunning ? "default" : "pointer", fontWeight: 600, fontSize: 12,
+        }}>
+          {isAgentRunning ? "Agent working..." : "Agent: organize + add tasks"}
+        </button>
+      </div>
     </div>
   );
 }`,

--- a/apps/notebook/src/content/chapters/03-generative-ui.ts
+++ b/apps/notebook/src/content/chapters/03-generative-ui.ts
@@ -1,0 +1,154 @@
+import type { Chapter } from "@/lib/types";
+
+export const generativeUi: Chapter = {
+  id: "generative-ui",
+  title: "Generative UI",
+  description:
+    "How the agent generates rich, interactive UI components beyond text.",
+  icon: "🎨",
+  cells: [
+    {
+      type: "markdown",
+      id: "genui-concept",
+      content: `# Generative UI
+
+The most powerful feature of OpenGenerativeUI is **Generative UI** — the agent doesn't just return text responses, it renders **actual React components** in the chat stream.
+
+This means the agent can produce:
+- **Charts** (bar charts, pie charts) with real data
+- **Interactive widgets** (HTML/SVG/3D rendered in sandboxed iframes)
+- **Planning cards** that show the agent's thinking process
+- **Forms** for human-in-the-loop interactions
+
+## How it works
+
+CopilotKit provides hooks to register "component tools" that the agent can call. When the agent calls one of these tools, instead of returning text, it renders a React component with the tool's parameters as props.`,
+    },
+    {
+      type: "code",
+      id: "genui-register",
+      language: "tsx",
+      filename: "apps/app/src/hooks/use-generative-ui-examples.tsx",
+      content: `import { useComponent } from "@copilotkit/react-core";
+import { PieChart, PieChartProps } from "../components/generative-ui/charts/pie-chart";
+import { BarChart, BarChartProps } from "../components/generative-ui/charts/bar-chart";
+import { WidgetRenderer, WidgetProps } from "../components/generative-ui/widget-renderer";
+
+export function useGenerativeUIExamples() {
+  // Register a pie chart component the agent can render
+  useComponent("pieChart", {
+    component: PieChart,
+    schema: PieChartProps,    // Zod schema for props validation
+    description: "Render a pie chart with labeled data segments",
+  });
+
+  // Register a bar chart
+  useComponent("barChart", {
+    component: BarChart,
+    schema: BarChartProps,
+    description: "Render a bar chart with labeled data",
+  });
+
+  // Register the widget renderer (most flexible - renders any HTML)
+  useComponent("widgetRenderer", {
+    component: WidgetRenderer,
+    schema: WidgetProps,
+    description: "Render interactive HTML/SVG/3D visualizations",
+  });
+}`,
+    },
+    {
+      type: "markdown",
+      id: "genui-props",
+      content: `## Props are validated with Zod
+
+Each component tool defines a **Zod schema** for its props. This serves two purposes:
+1. The agent sees the schema as part of the tool description, so it knows exactly what data to provide
+2. Props are validated before the component renders, preventing runtime errors`,
+    },
+    {
+      type: "code",
+      id: "genui-zod",
+      language: "tsx",
+      filename: "Chart props schema",
+      content: `import { z } from "zod";
+
+export const PieChartProps = z.object({
+  title: z.string().describe("The title displayed above the chart"),
+  description: z.string().describe("A brief description of the data"),
+  data: z.array(
+    z.object({
+      label: z.string().describe("Segment label"),
+      value: z.number().describe("Segment value"),
+    })
+  ).describe("The data segments for the pie chart"),
+});`,
+    },
+    {
+      type: "playground",
+      id: "genui-chart-playground",
+      title: "Try it: Build a Chart Component",
+      dependencies: { recharts: "2.12.7" },
+      files: {
+        "/App.js": `import { PieChart, Pie, Cell, Legend, Tooltip, ResponsiveContainer } from "recharts";
+
+const COLORS = ["#9599CC", "#85E0CE", "#BEC2FF", "#A8E9DC", "#D4D7FF", "#1B936F"];
+
+// Try editing this data!
+const data = [
+  { label: "React", value: 40 },
+  { label: "Python", value: 25 },
+  { label: "TypeScript", value: 20 },
+  { label: "CSS", value: 15 },
+];
+
+export default function App() {
+  return (
+    <div style={{ fontFamily: "'Plus Jakarta Sans', sans-serif", padding: 20 }}>
+      <h3 style={{ fontSize: 16, fontWeight: 700, marginBottom: 4 }}>
+        Languages Used
+      </h3>
+      <p style={{ fontSize: 13, color: "#6b7280", marginBottom: 16 }}>
+        Distribution of languages in the codebase
+      </p>
+      <ResponsiveContainer width="100%" height={280}>
+        <PieChart>
+          <Pie
+            data={data}
+            dataKey="value"
+            nameKey="label"
+            cx="50%"
+            cy="50%"
+            outerRadius={90}
+            strokeWidth={2}
+          >
+            {data.map((_, i) => (
+              <Cell key={i} fill={COLORS[i % COLORS.length]} />
+            ))}
+          </Pie>
+          <Tooltip />
+          <Legend />
+        </PieChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}`,
+      },
+    },
+    {
+      type: "markdown",
+      id: "genui-widget",
+      content: `## The Widget Renderer
+
+The most flexible generative UI component is the **Widget Renderer**. It takes arbitrary HTML/SVG/CSS and renders it in a **sandboxed iframe** with:
+
+- A full design system (CSS variables, fonts)
+- Import maps for libraries (Three.js, D3, GSAP, Chart.js)
+- A communication bridge (\`window.sendPrompt()\` to send messages back to the agent)
+- Auto-resizing based on content height
+- Efficient streaming updates via Idiomorph DOM diffing
+
+This is what enables the agent to produce 3D visualizations, interactive diagrams, and custom widgets on the fly.`,
+    },
+  ],
+};

--- a/apps/notebook/src/content/chapters/03-generative-ui.ts
+++ b/apps/notebook/src/content/chapters/03-generative-ui.ts
@@ -1,154 +1,270 @@
 import type { Chapter } from "@/lib/types";
 
-export const generativeUi: Chapter = {
-  id: "generative-ui",
-  title: "Generative UI",
+export const copilotKitIntegration: Chapter = {
+  id: "copilotkit",
+  title: "CopilotKit Integration",
   description:
-    "How the agent generates rich, interactive UI components beyond text.",
-  icon: "🎨",
+    "How React hooks bridge the frontend to the AI agent.",
+  icon: "🔌",
   cells: [
     {
       type: "markdown",
-      id: "genui-concept",
-      content: `# Generative UI
+      id: "ck-overview",
+      content: `# CopilotKit Integration
 
-The most powerful feature of OpenGenerativeUI is **Generative UI** — the agent doesn't just return text responses, it renders **actual React components** in the chat stream.
+CopilotKit provides the bridge between the React frontend and the LangGraph agent. It works through three layers:
 
-This means the agent can produce:
-- **Charts** (bar charts, pie charts) with real data
-- **Interactive widgets** (HTML/SVG/3D rendered in sandboxed iframes)
-- **Planning cards** that show the agent's thinking process
-- **Forms** for human-in-the-loop interactions
+1. **Provider** — \`<CopilotKit runtimeUrl="/api/copilotkit">\` wraps the app
+2. **Runtime** — A Next.js API route that connects to the LangGraph agent via \`LangGraphHttpAgent\`
+3. **Hooks** — React hooks that register component tools, frontend tools, and render tools
 
-## How it works
-
-CopilotKit provides hooks to register "component tools" that the agent can call. When the agent calls one of these tools, instead of returning text, it renders a React component with the tool's parameters as props.`,
+The key insight: CopilotKit lets you register **React components as agent tools**. When the agent calls a tool like \`widgetRenderer\`, instead of returning text, CopilotKit renders your component inline in the chat.`,
     },
     {
       type: "code",
-      id: "genui-register",
+      id: "ck-runtime",
+      language: "typescript",
+      filename: "apps/app/src/app/api/copilotkit/route.ts",
+      content: `import { CopilotRuntime } from "@copilotkit/runtime";
+import { LangGraphHttpAgent } from "@copilotkit/runtime";
+
+// Connect to the LangGraph agent backend
+const defaultAgent = new LangGraphHttpAgent({
+  deploymentUrl: process.env.LANGGRAPH_DEPLOYMENT_URL || "http://localhost:8123",
+  agentName: "sample_agent",
+});
+
+const runtime = new CopilotRuntime({
+  agents: { default: defaultAgent },
+
+  // Auto-inject A2UI (Agent-to-UI) tool
+  a2ui: { injectA2UITool: true },
+
+  // Optional: connect MCP server for skills
+  mcpApps: {
+    servers: process.env.MCP_SERVER_URL ? [{
+      type: "http",
+      url: process.env.MCP_SERVER_URL,
+      serverId: "example_mcp_app",
+    }] : [],
+  },
+});`,
+    },
+    {
+      type: "markdown",
+      id: "ck-hooks-intro",
+      content: `## Hook Registration
+
+All CopilotKit hooks are registered in a single custom hook. Here's the full set used in OpenGenerativeUI:
+
+| Hook | Name | What it does |
+|------|------|-------------|
+| \`useComponent()\` | \`pieChart\` | Registers PieChart as a renderable tool |
+| \`useComponent()\` | \`barChart\` | Registers BarChart as a renderable tool |
+| \`useComponent()\` | \`widgetRenderer\` | Registers the iframe widget renderer |
+| \`useFrontendTool()\` | \`toggleTheme\` | Agent can switch light/dark mode |
+| \`useRenderTool()\` | \`plan_visualization\` | Shows PlanCard while agent plans |
+| \`useHumanInTheLoop()\` | \`scheduleTime\` | Pauses for user to pick a meeting time |
+| \`useDefaultRenderTool()\` | (all tools) | Shows reasoning indicator for any tool |`,
+    },
+    {
+      type: "code",
+      id: "ck-hooks-code",
       language: "tsx",
       filename: "apps/app/src/hooks/use-generative-ui-examples.tsx",
-      content: `import { useComponent } from "@copilotkit/react-core";
-import { PieChart, PieChartProps } from "../components/generative-ui/charts/pie-chart";
-import { BarChart, BarChartProps } from "../components/generative-ui/charts/bar-chart";
-import { WidgetRenderer, WidgetProps } from "../components/generative-ui/widget-renderer";
+      content: `import { useComponent, useFrontendTool, useRenderTool,
+         useDefaultRenderTool, useHumanInTheLoop } from "@copilotkit/react-core";
 
 export function useGenerativeUIExamples() {
-  // Register a pie chart component the agent can render
+  // 1. Component tools — agent renders these in the chat stream
   useComponent("pieChart", {
     component: PieChart,
-    schema: PieChartProps,    // Zod schema for props validation
+    schema: PieChartProps,  // Zod schema → agent sees as tool params
     description: "Render a pie chart with labeled data segments",
   });
 
-  // Register a bar chart
-  useComponent("barChart", {
-    component: BarChart,
-    schema: BarChartProps,
-    description: "Render a bar chart with labeled data",
-  });
-
-  // Register the widget renderer (most flexible - renders any HTML)
   useComponent("widgetRenderer", {
     component: WidgetRenderer,
-    schema: WidgetProps,
-    description: "Render interactive HTML/SVG/3D visualizations",
+    schema: z.object({
+      title: z.string(),
+      description: z.string(),
+      html: z.string().describe("Self-contained HTML with inline styles and scripts"),
+    }),
+    description: "Render interactive HTML/SVG/3D visualizations in a sandboxed iframe",
+  });
+
+  // 2. Frontend tool — agent calls JS in the browser (no UI)
+  const { setTheme } = useTheme();
+  useFrontendTool("toggleTheme", {
+    description: "Toggle between light and dark mode",
+    schema: z.object({}),
+    handler: () => {
+      setTheme(currentTheme === "dark" ? "light" : "dark");
+      return "Theme toggled";
+    },
+  });
+
+  // 3. Render tool — runs logic AND shows UI during execution
+  useRenderTool("plan_visualization", {
+    description: "Show planning progress before building a visualization",
+    schema: z.object({
+      status: z.string(),
+      approach: z.string(),
+      technology: z.string(),
+      keyElements: z.array(z.string()),
+    }),
+    component: PlanCard,  // Shows while the tool executes
+    handler: (props) => \`Plan: \${props.approach}\`,
+  });
+
+  // 4. Human-in-the-loop — pauses agent, waits for user input
+  useHumanInTheLoop("scheduleTime", {
+    description: "Schedule a meeting time with the user",
+    schema: z.object({
+      reasonForScheduling: z.string(),
+      meetingDuration: z.string(),
+    }),
+    component: MeetingTimePicker,  // User picks a time, then agent resumes
+  });
+
+  // 5. Default render tool — shows reasoning for ALL tool calls
+  useDefaultRenderTool({
+    component: ToolReasoning,
+    excludeTools: ["generate_form"],
   });
 }`,
     },
     {
       type: "markdown",
-      id: "genui-props",
-      content: `## Props are validated with Zod
+      id: "ck-useagent",
+      content: `## useAgent() — Reading and Writing Agent State
 
-Each component tool defines a **Zod schema** for its props. This serves two purposes:
-1. The agent sees the schema as part of the tool description, so it knows exactly what data to provide
-2. Props are validated before the component renders, preventing runtime errors`,
+The \`useAgent()\` hook gives the frontend direct access to the agent's state. In OpenGenerativeUI, this powers the todo canvas:
+
+- \`agent.state.todos\` — Read the current todo list
+- \`agent.setState({ todos: [...] })\` — Update from the frontend
+- \`agent.isRunning\` — Shows loading state while agent processes
+
+Both user edits and agent tool calls modify the same state. CopilotKit handles the bidirectional sync automatically.`,
     },
     {
       type: "code",
-      id: "genui-zod",
+      id: "ck-canvas",
       language: "tsx",
-      filename: "Chart props schema",
-      content: `import { z } from "zod";
+      filename: "apps/app/src/components/canvas/index.tsx",
+      content: `import { useAgent } from "@copilotkit/react-core";
 
-export const PieChartProps = z.object({
-  title: z.string().describe("The title displayed above the chart"),
-  description: z.string().describe("A brief description of the data"),
-  data: z.array(
-    z.object({
-      label: z.string().describe("Segment label"),
-      value: z.number().describe("Segment value"),
-    })
-  ).describe("The data segments for the pie chart"),
-});`,
+export function Canvas() {
+  const { agent } = useAgent();
+
+  return (
+    <TodoList
+      // Read from agent state
+      todos={agent.state?.todos || []}
+      // Write to agent state (syncs to backend)
+      onUpdate={(updated) => agent.setState({ todos: updated })}
+      // React to agent activity
+      isAgentRunning={agent.isRunning}
+    />
+  );
+}`,
     },
     {
       type: "playground",
-      id: "genui-chart-playground",
-      title: "Try it: Build a Chart Component",
-      dependencies: { recharts: "2.12.7" },
+      id: "ck-playground",
+      title: "Try it: Component Tool Registration",
       files: {
-        "/App.js": `import { PieChart, Pie, Cell, Legend, Tooltip, ResponsiveContainer } from "recharts";
+        "/App.js": `import { useState } from "react";
 
-const COLORS = ["#9599CC", "#85E0CE", "#BEC2FF", "#A8E9DC", "#D4D7FF", "#1B936F"];
+// Simulating how useComponent() works:
+// The agent calls "renderCard" with props → CopilotKit renders the component
 
-// Try editing this data!
-const data = [
-  { label: "React", value: 40 },
-  { label: "Python", value: 25 },
-  { label: "TypeScript", value: 20 },
-  { label: "CSS", value: 15 },
+function AgentCard({ title, items, color }) {
+  return (
+    <div style={{
+      padding: 16, borderRadius: 12, fontFamily: "system-ui, sans-serif",
+      background: color === "mint" ? "#f0fdf4" : "#f5f3ff",
+      border: \`1px solid \${color === "mint" ? "#a7f3d0" : "#c4b5fd"}\`,
+    }}>
+      <h3 style={{ fontSize: 15, fontWeight: 600, margin: "0 0 8px 0" }}>{title}</h3>
+      <ul style={{ margin: 0, paddingLeft: 20, fontSize: 13, lineHeight: 1.8 }}>
+        {items.map((item, i) => <li key={i}>{item}</li>)}
+      </ul>
+    </div>
+  );
+}
+
+// Simulated tool calls from the agent
+const toolCalls = [
+  {
+    name: "renderCard",
+    args: {
+      title: "Frontend Stack",
+      items: ["Next.js 16 with Turbopack", "React 19", "TailwindCSS 4", "CopilotKit v2 hooks"],
+      color: "lilac",
+    },
+  },
+  {
+    name: "renderCard",
+    args: {
+      title: "Agent Stack",
+      items: ["LangGraph (Python)", "create_deep_agent", "CopilotKitMiddleware", "BoundedMemorySaver"],
+      color: "mint",
+    },
+  },
 ];
 
 export default function App() {
+  const [rendered, setRendered] = useState([]);
+  const [calling, setCalling] = useState(false);
+
+  const simulateAgent = async () => {
+    setCalling(true);
+    for (const call of toolCalls) {
+      await new Promise(r => setTimeout(r, 800));
+      setRendered(prev => [...prev, call]);
+    }
+    setCalling(false);
+  };
+
   return (
-    <div style={{ fontFamily: "'Plus Jakarta Sans', sans-serif", padding: 20 }}>
-      <h3 style={{ fontSize: 16, fontWeight: 700, marginBottom: 4 }}>
-        Languages Used
-      </h3>
+    <div style={{ fontFamily: "system-ui, sans-serif", padding: 20 }}>
+      <h2 style={{ fontSize: 16, fontWeight: 700, marginBottom: 12 }}>
+        useComponent() Simulation
+      </h2>
       <p style={{ fontSize: 13, color: "#6b7280", marginBottom: 16 }}>
-        Distribution of languages in the codebase
+        When the agent calls a component tool, CopilotKit renders the React component inline:
       </p>
-      <ResponsiveContainer width="100%" height={280}>
-        <PieChart>
-          <Pie
-            data={data}
-            dataKey="value"
-            nameKey="label"
-            cx="50%"
-            cy="50%"
-            outerRadius={90}
-            strokeWidth={2}
-          >
-            {data.map((_, i) => (
-              <Cell key={i} fill={COLORS[i % COLORS.length]} />
-            ))}
-          </Pie>
-          <Tooltip />
-          <Legend />
-        </PieChart>
-      </ResponsiveContainer>
+
+      <div style={{ display: "flex", flexDirection: "column", gap: 12, marginBottom: 16 }}>
+        {rendered.map((call, i) => (
+          <div key={i}>
+            <div style={{
+              fontSize: 11, fontFamily: "monospace", color: "#9599CC",
+              marginBottom: 4,
+            }}>
+              agent calls: {call.name}({JSON.stringify(call.args).slice(0, 60)}...)
+            </div>
+            <AgentCard {...call.args} />
+          </div>
+        ))}
+      </div>
+
+      <button
+        onClick={simulateAgent}
+        disabled={calling}
+        style={{
+          padding: "8px 16px", borderRadius: 8, border: "none",
+          background: calling ? "#d1d5db" : "#9599CC", color: "#fff",
+          cursor: calling ? "default" : "pointer", fontWeight: 600, fontSize: 13,
+        }}
+      >
+        {calling ? "Agent rendering..." : "Simulate Agent Tool Calls"}
+      </button>
     </div>
   );
 }`,
       },
-    },
-    {
-      type: "markdown",
-      id: "genui-widget",
-      content: `## The Widget Renderer
-
-The most flexible generative UI component is the **Widget Renderer**. It takes arbitrary HTML/SVG/CSS and renders it in a **sandboxed iframe** with:
-
-- A full design system (CSS variables, fonts)
-- Import maps for libraries (Three.js, D3, GSAP, Chart.js)
-- A communication bridge (\`window.sendPrompt()\` to send messages back to the agent)
-- Auto-resizing based on content height
-- Efficient streaming updates via Idiomorph DOM diffing
-
-This is what enables the agent to produce 3D visualizations, interactive diagrams, and custom widgets on the fly.`,
     },
   ],
 };

--- a/apps/notebook/src/content/chapters/04-copilotkit-hooks.ts
+++ b/apps/notebook/src/content/chapters/04-copilotkit-hooks.ts
@@ -12,15 +12,7 @@ export const deepAgent: Chapter = {
       id: "da-overview",
       content: `# The Deep Agent
 
-The agent backend uses \`create_deep_agent\` from the \`deepagents\` library — a LangGraph-based agent factory that supports tools, middleware, skills, and bounded memory.
-
-The agent is configured in a single file (\`main.py\`) with:
-- A language model (GPT-5.4)
-- A set of tools (todos, planning, data query, form generation)
-- CopilotKit middleware (bridges agent state to the frontend)
-- A skills directory (loaded at runtime for contextual instructions)
-- A system prompt defining the visualization workflow
-- A bounded memory saver (prevents OOM on constrained hosts)`,
+The agent backend uses \`create_deep_agent\` from the \`deepagents\` library — a LangGraph-based agent factory that supports tools, middleware, skills, and bounded memory.`,
     },
     {
       type: "code",
@@ -29,7 +21,6 @@ The agent is configured in a single file (\`main.py\`) with:
       filename: "apps/agent/main.py",
       content: `from deepagents import create_deep_agent
 from copilotkit import CopilotKitMiddleware, LangGraphAGUIAgent
-from ag_ui_langgraph import add_langgraph_fastapi_endpoint
 from langchain_openai import ChatOpenAI
 
 agent = create_deep_agent(
@@ -39,128 +30,232 @@ agent = create_deep_agent(
     context_schema=AgentState,
     skills=[str(Path(__file__).parent / "skills")],
     checkpointer=BoundedMemorySaver(max_threads=200),
-    system_prompt="...",  # See below
-)
-
-# FastAPI endpoint — CopilotKit runtime connects here
-app = FastAPI()
-add_langgraph_fastapi_endpoint(
-    app=app,
-    agent=LangGraphAGUIAgent(
-        name="sample_agent",
-        description="CopilotKit + LangGraph demo agent",
-        graph=agent,
-    ),
-    path="/",
+    system_prompt="...",
 )`,
     },
     {
-      type: "markdown",
-      id: "da-state",
-      content: `## Agent State Schema
-
-State is defined as a Python TypedDict. CopilotKit syncs this bidirectionally with the frontend via \`useAgent()\`:`,
-    },
-    {
       type: "code",
-      id: "da-state-code",
-      language: "python",
-      filename: "apps/agent/src/todos.py",
-      content: `from langchain.agents import AgentState as BaseAgentState
-from typing import TypedDict, Literal
-
-class Todo(TypedDict):
-    id: str
-    title: str
-    description: str
-    emoji: str
-    status: Literal["pending", "completed"]
-
-class AgentState(BaseAgentState):
-    todos: list[Todo]`,
-    },
-    {
-      type: "markdown",
-      id: "da-tools",
-      content: `## Tools
-
-The agent has 5 tools, each serving a specific role:
-
-| Tool | Purpose | Returns |
-|------|---------|---------|
-| \`manage_todos\` | Add/update/remove todos | \`Command(update={todos: [...]})\` — updates state |
-| \`get_todos\` | Read current todos | Current state.todos |
-| \`plan_visualization\` | **Mandatory** before any visual | Plan summary string |
-| \`query_data\` | Fetch CSV data for charts | Cached row dictionaries |
-| \`generate_form\` | Produce login/contact forms | Surface update events |
-
-The \`manage_todos\` tool is the most important — it uses LangGraph's \`Command\` to atomically update state:`,
-    },
-    {
-      type: "code",
-      id: "da-manage-todos",
+      id: "da-tools-code",
       language: "python",
       filename: "apps/agent/src/todos.py — manage_todos",
       content: `@tool
 def manage_todos(todos: list[Todo], runtime: ToolRuntime) -> Command:
     """Manage the current todos."""
-    # Ensure all todos have unique IDs
     for todo in todos:
         if "id" not in todo or not todo["id"]:
             todo["id"] = str(uuid.uuid4())
 
-    # Atomic state update via LangGraph Command
     return Command(update={
         "todos": todos,
-        "messages": [
-            ToolMessage(
-                content="Successfully updated todos",
-                tool_call_id=runtime.tool_call_id
-            )
-        ]
+        "messages": [ToolMessage(
+            content="Successfully updated todos",
+            tool_call_id=runtime.tool_call_id
+        )]
     })`,
     },
     {
-      type: "code",
-      id: "da-plan",
-      language: "python",
-      filename: "apps/agent/src/plan.py — plan_visualization",
-      content: `@tool
-def plan_visualization(
-    approach: str, technology: str, key_elements: list[str]
-) -> str:
-    """Plan a visualization before building it. MUST be called before
-    widgetRenderer, pieChart, or barChart.
+      type: "markdown",
+      id: "da-workflow",
+      content: `## Mandatory Visualization Workflow
 
-    Args:
-        approach: One sentence describing the visualization strategy.
-        technology: The primary technology (e.g. "Three.js", "D3.js",
-            "inline SVG", "Chart.js").
-        key_elements: 2-4 concise bullet points of what will be built.
-    """
-    elements = "\\n".join(f"  - {e}" for e in key_elements)
-    return f"Plan: {approach}\\nTech: {technology}\\n{elements}"`,
+The system prompt enforces a strict 4-step pipeline for every visual response. The playground below runs a real simulation — watch the agent execute each tool, produce actual output, and render the final widget:`,
     },
     {
-      type: "markdown",
-      id: "da-system-prompt",
-      content: `## System Prompt
+      type: "playground",
+      id: "da-pipeline-playground",
+      title: "Live: Full agent tool execution pipeline with rendered output",
+      files: {
+        "/App.js": `import { useState, useRef, useEffect } from "react";
 
-The system prompt encodes the **mandatory visualization workflow** and quality standards:
+// Full agent pipeline simulation that ACTUALLY RENDERS the visualization
 
-1. **Acknowledge** → **Plan** → **Build** → **Narrate** (never skip plan)
-2. \`<script type="module">\` is REQUIRED for import map usage
-3. 3D content MUST use Three.js with WebGL, PBR materials, multiple lights, OrbitControls
-4. Every visualization should be "polished and portfolio-ready"
-5. Always call \`query_data\` before showing charts
-6. Be brief about CopilotKit/LangGraph explanations (1-2 sentences)`,
-    },
-    {
-      type: "markdown",
-      id: "da-memory",
-      content: `## Bounded Memory
+export default function App() {
+  const [phase, setPhase] = useState("idle"); // idle, ack, plan, build, narrate, done
+  const [chatLog, setChatLog] = useState([]);
+  const [widgetHtml, setWidgetHtml] = useState("");
+  const iframeRef = useRef(null);
+  const bottomRef = useRef(null);
 
-The default LangGraph \`MemorySaver\` stores all conversation threads in memory forever — a problem on memory-constrained hosts (512MB). \`BoundedMemorySaver\` adds FIFO eviction:`,
+  useEffect(() => { bottomRef.current?.scrollIntoView({ behavior: "smooth" }); }, [chatLog, widgetHtml]);
+
+  // Update iframe when widget HTML is set
+  useEffect(() => {
+    if (!iframeRef.current || !widgetHtml) return;
+    const doc = iframeRef.current.contentDocument;
+    if (!doc) return;
+    doc.open();
+    doc.write(\`<!DOCTYPE html><html><body style="margin:0">\${widgetHtml}</body></html>\`);
+    doc.close();
+  }, [widgetHtml]);
+
+  const runPipeline = async () => {
+    setChatLog([]);
+    setWidgetHtml("");
+
+    // Step 1: Acknowledge
+    setPhase("ack");
+    await new Promise(r => setTimeout(r, 600));
+    setChatLog(prev => [...prev, {
+      type: "text",
+      content: "I'll create an interactive metrics dashboard showing the agent's tool usage and performance data.",
+    }]);
+
+    // Step 2: Plan
+    setPhase("plan");
+    await new Promise(r => setTimeout(r, 800));
+    setChatLog(prev => [...prev, {
+      type: "plan",
+      data: {
+        approach: "Multi-card dashboard with animated bar chart and live metric counters",
+        technology: "HTML + CSS (no dependencies)",
+        keyElements: [
+          "Metrics cards row with tool call count, latency, success rate",
+          "Horizontal bar chart showing tool usage distribution",
+          "Animated entrance transitions",
+          "Design system CSS variables for theming",
+        ],
+      },
+    }]);
+
+    // Step 3: Build (stream the actual widget)
+    setPhase("build");
+    await new Promise(r => setTimeout(r, 500));
+    setChatLog(prev => [...prev, { type: "building" }]);
+
+    const widgetContent = \`<style>
+      body { font-family: system-ui, -apple-system, sans-serif; padding: 20px; margin: 0; background: #fff; }
+      .grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; margin-bottom: 20px; }
+      .metric-card { padding: 14px; border-radius: 12px; border: 0.5px solid rgba(0,0,0,0.12); }
+      .metric-label { font-size: 11px; color: #73726c; margin-bottom: 4px; }
+      .metric-value { font-size: 24px; font-weight: 500; }
+      .bar-section { margin-top: 8px; }
+      .bar-title { font-size: 14px; font-weight: 500; color: #1a1a1a; margin-bottom: 12px; }
+      .bar-row { display: flex; align-items: center; gap: 8px; margin-bottom: 8px; }
+      .bar-label { width: 100px; font-size: 12px; color: #73726c; text-align: right; }
+      .bar-track { flex: 1; height: 24px; background: #f7f6f3; border-radius: 6px; overflow: hidden; }
+      .bar-fill { height: 100%; border-radius: 6px; animation: grow 1s ease-out forwards; transform-origin: left; }
+      .bar-pct { width: 36px; font-size: 12px; color: #73726c; }
+      @keyframes grow { from { transform: scaleX(0); } to { transform: scaleX(1); } }
+      @keyframes fadeUp { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: translateY(0); } }
+      .animate { animation: fadeUp 0.5s ease-out forwards; opacity: 0; }
+    </style>
+    <div class="grid">
+      <div class="metric-card animate" style="background:#EDE9F5;animation-delay:0.1s">
+        <div class="metric-label">Tool calls</div>
+        <div class="metric-value" style="color:#5B3FA0">1,247</div>
+      </div>
+      <div class="metric-card animate" style="background:#E1F5EE;animation-delay:0.2s">
+        <div class="metric-label">Avg latency</div>
+        <div class="metric-value" style="color:#0F6E56">340ms</div>
+      </div>
+      <div class="metric-card animate" style="background:#E3EFFC;animation-delay:0.3s">
+        <div class="metric-label">Success rate</div>
+        <div class="metric-value" style="color:#2663B3">99.2%</div>
+      </div>
+      <div class="metric-card animate" style="background:#FEF3DC;animation-delay:0.4s">
+        <div class="metric-label">Active threads</div>
+        <div class="metric-value" style="color:#B8860B">42</div>
+      </div>
+    </div>
+    <div class="bar-section animate" style="animation-delay:0.6s">
+      <div class="bar-title">Tool usage breakdown</div>
+      <div class="bar-row"><span class="bar-label">widgetRenderer</span><div class="bar-track"><div class="bar-fill" style="width:78%;background:#5B3FA0;animation-delay:0.8s"></div></div><span class="bar-pct">78%</span></div>
+      <div class="bar-row"><span class="bar-label">pieChart</span><div class="bar-track"><div class="bar-fill" style="width:52%;background:#0F6E56;animation-delay:0.9s"></div></div><span class="bar-pct">52%</span></div>
+      <div class="bar-row"><span class="bar-label">manage_todos</span><div class="bar-track"><div class="bar-fill" style="width:35%;background:#2663B3;animation-delay:1.0s"></div></div><span class="bar-pct">35%</span></div>
+      <div class="bar-row"><span class="bar-label">query_data</span><div class="bar-track"><div class="bar-fill" style="width:20%;background:#C44D4D;animation-delay:1.1s"></div></div><span class="bar-pct">20%</span></div>
+      <div class="bar-row"><span class="bar-label">plan_viz</span><div class="bar-track"><div class="bar-fill" style="width:95%;background:#B8860B;animation-delay:1.2s"></div></div><span class="bar-pct">95%</span></div>
+    </div>\`;
+    await new Promise(r => setTimeout(r, 400));
+    setWidgetHtml(widgetContent);
+
+    // Step 4: Narrate
+    setPhase("narrate");
+    await new Promise(r => setTimeout(r, 1200));
+    setChatLog(prev => [...prev, {
+      type: "text",
+      content: "The dashboard shows the agent has handled 1,247 tool calls with a 99.2% success rate. The widgetRenderer is the most-used tool at 78%, followed by charts at 52%. Notice that plan_visualization runs at 95% — nearly every visual response includes a planning step.",
+    }]);
+    setPhase("done");
+  };
+
+  const phaseLabel = { idle: "", ack: "Acknowledging...", plan: "Planning...", build: "Building widget...", narrate: "Narrating...", done: "Complete" };
+
+  return (
+    <div style={{ fontFamily: "system-ui, sans-serif", display: "flex", flexDirection: "column", height: 560 }}>
+      <div style={{ flex: 1, overflow: "auto", padding: 16, display: "flex", flexDirection: "column", gap: 10 }}>
+        {chatLog.length === 0 && phase === "idle" && (
+          <div style={{ textAlign: "center", color: "#9ca3af", marginTop: 60, fontSize: 14 }}>
+            Click "Run Pipeline" to execute the full Acknowledge → Plan → Build → Narrate workflow
+          </div>
+        )}
+
+        {chatLog.map((msg, i) => {
+          if (msg.type === "text") return (
+            <div key={i} style={{ padding: "10px 14px", borderRadius: 10, background: "#f9fafb", fontSize: 13, color: "#374151", maxWidth: "90%", lineHeight: 1.5 }}>
+              {msg.content}
+            </div>
+          );
+          if (msg.type === "plan") return (
+            <div key={i} style={{ padding: 14, borderRadius: 10, background: "#EDE9F5", border: "1px solid #c4b5fd", maxWidth: "90%" }}>
+              <div style={{ fontSize: 11, fontWeight: 600, color: "#5B3FA0", textTransform: "uppercase", marginBottom: 6 }}>Plan</div>
+              <div style={{ fontSize: 13, fontWeight: 600, color: "#3E2B6F", marginBottom: 2 }}>{msg.data.approach}</div>
+              <div style={{ fontSize: 11, color: "#5B3FA0", marginBottom: 6 }}>Tech: {msg.data.technology}</div>
+              {msg.data.keyElements.map((el, j) => (
+                <div key={j} style={{ fontSize: 12, color: "#3E2B6F", paddingLeft: 12, position: "relative" }}>
+                  <span style={{ position: "absolute", left: 0 }}>-</span> {el}
+                </div>
+              ))}
+            </div>
+          );
+          if (msg.type === "building") return null;
+          return null;
+        })}
+
+        {/* The actual rendered widget */}
+        {widgetHtml && (
+          <div style={{ borderRadius: 10, overflow: "hidden", border: "1px solid #e5e7eb" }}>
+            <div style={{ padding: "6px 12px", background: "#f9fafb", borderBottom: "1px solid #e5e7eb", fontSize: 11, color: "#5B3FA0", fontWeight: 600 }}>
+              widgetRenderer output:
+            </div>
+            <iframe
+              ref={iframeRef}
+              sandbox="allow-scripts"
+              style={{ width: "100%", height: 280, border: "none", display: "block" }}
+            />
+          </div>
+        )}
+
+        <div ref={bottomRef} />
+      </div>
+
+      <div style={{ padding: 12, borderTop: "1px solid #e5e7eb", display: "flex", alignItems: "center", gap: 12 }}>
+        <button onClick={runPipeline} disabled={phase !== "idle" && phase !== "done"} style={{
+          padding: "10px 20px", borderRadius: 8, border: "none",
+          background: (phase !== "idle" && phase !== "done") ? "#e5e7eb" : "#5B3FA0",
+          color: (phase !== "idle" && phase !== "done") ? "#9ca3af" : "#fff",
+          cursor: (phase !== "idle" && phase !== "done") ? "default" : "pointer",
+          fontWeight: 600, fontSize: 14,
+        }}>
+          {phase === "done" ? "Run Again" : phase === "idle" ? "Run Pipeline" : phaseLabel[phase]}
+        </button>
+        {phase !== "idle" && (
+          <div style={{ display: "flex", gap: 4 }}>
+            {["ack","plan","build","narrate"].map((p, i) => (
+              <div key={p} style={{
+                padding: "3px 10px", borderRadius: 12, fontSize: 10, fontWeight: 600,
+                background: phase === p ? "#5B3FA0" : (["ack","plan","build","narrate"].indexOf(phase) > i || phase === "done") ? "#E1F5EE" : "#f0f0f0",
+                color: phase === p ? "#fff" : (["ack","plan","build","narrate"].indexOf(phase) > i || phase === "done") ? "#0F6E56" : "#9ca3af",
+              }}>
+                {p}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}`,
+      },
     },
     {
       type: "code",
@@ -178,134 +273,15 @@ The default LangGraph \`MemorySaver\` stores all conversation threads in memory 
     def put(self, config, checkpoint, metadata, new_versions):
         thread_id = config["configurable"]["thread_id"]
         self._insertion_order[thread_id] = None
-        self._insertion_order.move_to_end(thread_id)  # LRU tracking
+        self._insertion_order.move_to_end(thread_id)
 
         result = super().put(config, checkpoint, metadata, new_versions)
 
-        # Evict oldest threads when over limit
         while len(self.storage) > self.max_threads:
             oldest, _ = self._insertion_order.popitem(last=False)
             if oldest in self.storage:
                 del self.storage[oldest]
         return result`,
-    },
-    {
-      type: "playground",
-      id: "da-playground",
-      title: "Try it: Agent Tool Pipeline",
-      files: {
-        "/App.js": `import { useState } from "react";
-
-// Simulate the mandatory visualization workflow:
-// Acknowledge → Plan → Build → Narrate
-
-const steps = [
-  {
-    type: "acknowledge",
-    content: "I'll create a visualization showing the agent architecture.",
-  },
-  {
-    type: "tool_call",
-    tool: "plan_visualization",
-    args: {
-      approach: "Layered diagram showing data flow from user to agent to frontend",
-      technology: "inline SVG",
-      keyElements: [
-        "User input → CopilotKit runtime",
-        "LangGraph agent processes with tools",
-        "State syncs back to React frontend",
-        "Widget renderer displays result",
-      ],
-    },
-  },
-  {
-    type: "tool_call",
-    tool: "widgetRenderer",
-    args: { title: "Architecture Flow", description: "Agent data flow" },
-  },
-  {
-    type: "narrate",
-    content: "The diagram shows how a user message flows through CopilotKit to the LangGraph agent, which calls tools to update state, and the result syncs back to the frontend for rendering.",
-  },
-];
-
-export default function App() {
-  const [current, setCurrent] = useState(-1);
-  const [running, setRunning] = useState(false);
-
-  const runPipeline = async () => {
-    setRunning(true);
-    setCurrent(-1);
-    for (let i = 0; i < steps.length; i++) {
-      await new Promise(r => setTimeout(r, 1000));
-      setCurrent(i);
-    }
-    setRunning(false);
-  };
-
-  return (
-    <div style={{ fontFamily: "system-ui, sans-serif", padding: 20 }}>
-      <h2 style={{ fontSize: 16, fontWeight: 700, marginBottom: 4 }}>
-        Mandatory Visualization Workflow
-      </h2>
-      <p style={{ fontSize: 13, color: "#6b7280", marginBottom: 16 }}>
-        Every visual response follows: Acknowledge → Plan → Build → Narrate
-      </p>
-
-      <div style={{ display: "flex", flexDirection: "column", gap: 8, marginBottom: 16 }}>
-        {steps.map((step, i) => {
-          const active = i <= current;
-          const isCurrent = i === current;
-          return (
-            <div
-              key={i}
-              style={{
-                padding: 12, borderRadius: 8, fontSize: 13,
-                background: active ? (step.type === "tool_call" ? "#f5f3ff" : "#f9fafb") : "#fafafa",
-                border: \`1px solid \${isCurrent ? "#9599CC" : active ? "#e5e7eb" : "#f0f0f0"}\`,
-                opacity: active ? 1 : 0.4,
-                transition: "all 0.3s ease",
-              }}
-            >
-              <div style={{
-                fontSize: 11, fontWeight: 600, textTransform: "uppercase",
-                color: step.type === "tool_call" ? "#9599CC" : "#6b7280",
-                marginBottom: 4,
-              }}>
-                {step.type === "tool_call" ? \`🔧 \${step.tool}\` :
-                 step.type === "acknowledge" ? "💬 Acknowledge" :
-                 "📝 Narrate"}
-              </div>
-              {step.type === "tool_call" ? (
-                <pre style={{
-                  margin: 0, fontSize: 11, fontFamily: "monospace",
-                  color: "#374151", whiteSpace: "pre-wrap",
-                }}>
-                  {JSON.stringify(step.args, null, 2)}
-                </pre>
-              ) : (
-                <div style={{ color: "#374151" }}>{step.content}</div>
-              )}
-            </div>
-          );
-        })}
-      </div>
-
-      <button
-        onClick={runPipeline}
-        disabled={running}
-        style={{
-          padding: "8px 16px", borderRadius: 8, border: "none",
-          background: running ? "#d1d5db" : "#9599CC", color: "#fff",
-          cursor: running ? "default" : "pointer", fontWeight: 600, fontSize: 13,
-        }}
-      >
-        {running ? "Running pipeline..." : "Run Visualization Pipeline"}
-      </button>
-    </div>
-  );
-}`,
-      },
     },
   ],
 };

--- a/apps/notebook/src/content/chapters/04-copilotkit-hooks.ts
+++ b/apps/notebook/src/content/chapters/04-copilotkit-hooks.ts
@@ -1,250 +1,307 @@
 import type { Chapter } from "@/lib/types";
 
-export const copilotKitHooks: Chapter = {
-  id: "copilotkit-hooks",
-  title: "CopilotKit Hooks",
+export const deepAgent: Chapter = {
+  id: "deep-agent",
+  title: "Deep Agent",
   description:
-    "The React hooks that connect your frontend to the AI agent.",
-  icon: "🪝",
+    "The LangGraph agent: create_deep_agent, tools, state, and memory.",
+  icon: "🧠",
   cells: [
     {
       type: "markdown",
-      id: "hooks-overview",
-      content: `# CopilotKit Hooks
+      id: "da-overview",
+      content: `# The Deep Agent
 
-CopilotKit provides several React hooks that form the bridge between your frontend and the AI agent. Here's an overview of the key hooks used in OpenGenerativeUI:
+The agent backend uses \`create_deep_agent\` from the \`deepagents\` library — a LangGraph-based agent factory that supports tools, middleware, skills, and bounded memory.
 
-| Hook | Purpose |
-|------|---------|
-| \`useAgent()\` | Access agent state, send messages, check if agent is running |
-| \`useComponent()\` | Register a React component the agent can render in chat |
-| \`useFrontendTool()\` | Register a JS function the agent can call in the browser |
-| \`useRenderTool()\` | Register a tool that renders UI while executing |
-| \`useHumanInTheLoop()\` | Create async tools that pause for user input |`,
-    },
-    {
-      type: "markdown",
-      id: "hooks-useagent",
-      content: `## useAgent()
-
-The core hook. It gives you access to the agent's state and lets you interact with it:
-
-- \`agent.state\` — The current agent state (typed by your AgentState schema)
-- \`agent.setState()\` — Update the agent's state from the frontend
-- \`agent.isRunning\` — Whether the agent is currently processing
-- \`agent.sendMessage()\` — Send a message to the agent programmatically`,
+The agent is configured in a single file (\`main.py\`) with:
+- A language model (GPT-5.4)
+- A set of tools (todos, planning, data query, form generation)
+- CopilotKit middleware (bridges agent state to the frontend)
+- A skills directory (loaded at runtime for contextual instructions)
+- A system prompt defining the visualization workflow
+- A bounded memory saver (prevents OOM on constrained hosts)`,
     },
     {
       type: "code",
-      id: "hooks-useagent-code",
-      language: "tsx",
-      filename: "Using useAgent()",
-      content: `import { useAgent } from "@copilotkit/react-core";
+      id: "da-main",
+      language: "python",
+      filename: "apps/agent/main.py",
+      content: `from deepagents import create_deep_agent
+from copilotkit import CopilotKitMiddleware, LangGraphAGUIAgent
+from ag_ui_langgraph import add_langgraph_fastapi_endpoint
+from langchain_openai import ChatOpenAI
 
-function TodoCanvas() {
-  const { agent } = useAgent();
+agent = create_deep_agent(
+    model=ChatOpenAI(model=os.environ.get("LLM_MODEL", "gpt-5.4-2026-03-05")),
+    tools=[query_data, plan_visualization, *todo_tools, generate_form],
+    middleware=[CopilotKitMiddleware()],
+    context_schema=AgentState,
+    skills=[str(Path(__file__).parent / "skills")],
+    checkpointer=BoundedMemorySaver(max_threads=200),
+    system_prompt="...",  # See below
+)
 
-  // Read state
-  const todos = agent.state?.todos || [];
-
-  // Write state (syncs to agent backend)
-  const addTodo = (todo) => {
-    agent.setState({ todos: [...todos, todo] });
-  };
-
-  // Check if agent is working
-  if (agent.isRunning) {
-    return <LoadingSpinner />;
-  }
-
-  return <TodoList todos={todos} onAdd={addTodo} />;
-}`,
+# FastAPI endpoint — CopilotKit runtime connects here
+app = FastAPI()
+add_langgraph_fastapi_endpoint(
+    app=app,
+    agent=LangGraphAGUIAgent(
+        name="sample_agent",
+        description="CopilotKit + LangGraph demo agent",
+        graph=agent,
+    ),
+    path="/",
+)`,
     },
     {
       type: "markdown",
-      id: "hooks-usecomponent",
-      content: `## useComponent()
+      id: "da-state",
+      content: `## Agent State Schema
 
-Registers a React component as a tool the agent can call. When the agent calls this tool, instead of returning text, CopilotKit renders your component inline in the chat with the agent-provided props:`,
+State is defined as a Python TypedDict. CopilotKit syncs this bidirectionally with the frontend via \`useAgent()\`:`,
     },
     {
       type: "code",
-      id: "hooks-usecomponent-code",
-      language: "tsx",
-      filename: "Registering a component tool",
-      content: `import { useComponent } from "@copilotkit/react-core";
-import { z } from "zod";
+      id: "da-state-code",
+      language: "python",
+      filename: "apps/agent/src/todos.py",
+      content: `from langchain.agents import AgentState as BaseAgentState
+from typing import TypedDict, Literal
 
-function MyChart({ title, data }) {
-  return (
-    <div>
-      <h3>{title}</h3>
-      {/* render chart with data */}
-    </div>
-  );
-}
+class Todo(TypedDict):
+    id: str
+    title: str
+    description: str
+    emoji: str
+    status: Literal["pending", "completed"]
 
-// In your hook setup:
-useComponent("myChart", {
-  component: MyChart,
-  schema: z.object({
-    title: z.string(),
-    data: z.array(z.object({
-      label: z.string(),
-      value: z.number(),
-    })),
-  }),
-  description: "Render a custom chart",
-});`,
+class AgentState(BaseAgentState):
+    todos: list[Todo]`,
     },
     {
       type: "markdown",
-      id: "hooks-usefrontendtool",
-      content: `## useFrontendTool()
+      id: "da-tools",
+      content: `## Tools
 
-Registers a JavaScript function that the agent can call to perform actions in the browser. Unlike \`useComponent()\`, this doesn't render UI — it executes logic:`,
+The agent has 5 tools, each serving a specific role:
+
+| Tool | Purpose | Returns |
+|------|---------|---------|
+| \`manage_todos\` | Add/update/remove todos | \`Command(update={todos: [...]})\` — updates state |
+| \`get_todos\` | Read current todos | Current state.todos |
+| \`plan_visualization\` | **Mandatory** before any visual | Plan summary string |
+| \`query_data\` | Fetch CSV data for charts | Cached row dictionaries |
+| \`generate_form\` | Produce login/contact forms | Surface update events |
+
+The \`manage_todos\` tool is the most important — it uses LangGraph's \`Command\` to atomically update state:`,
     },
     {
       type: "code",
-      id: "hooks-usefrontendtool-code",
-      language: "tsx",
-      filename: "Frontend tool: theme toggle",
-      content: `import { useFrontendTool } from "@copilotkit/react-core";
+      id: "da-manage-todos",
+      language: "python",
+      filename: "apps/agent/src/todos.py — manage_todos",
+      content: `@tool
+def manage_todos(todos: list[Todo], runtime: ToolRuntime) -> Command:
+    """Manage the current todos."""
+    # Ensure all todos have unique IDs
+    for todo in todos:
+        if "id" not in todo or not todo["id"]:
+            todo["id"] = str(uuid.uuid4())
 
-useFrontendTool("toggleTheme", {
-  description: "Toggle between light and dark theme",
-  schema: z.object({
-    theme: z.enum(["light", "dark"]).describe("The theme to switch to"),
-  }),
-  handler: ({ theme }) => {
-    document.documentElement.classList.remove("light", "dark");
-    document.documentElement.classList.add(theme);
-    return \`Switched to \${theme} mode\`;
-  },
-});`,
+    # Atomic state update via LangGraph Command
+    return Command(update={
+        "todos": todos,
+        "messages": [
+            ToolMessage(
+                content="Successfully updated todos",
+                tool_call_id=runtime.tool_call_id
+            )
+        ]
+    })`,
+    },
+    {
+      type: "code",
+      id: "da-plan",
+      language: "python",
+      filename: "apps/agent/src/plan.py — plan_visualization",
+      content: `@tool
+def plan_visualization(
+    approach: str, technology: str, key_elements: list[str]
+) -> str:
+    """Plan a visualization before building it. MUST be called before
+    widgetRenderer, pieChart, or barChart.
+
+    Args:
+        approach: One sentence describing the visualization strategy.
+        technology: The primary technology (e.g. "Three.js", "D3.js",
+            "inline SVG", "Chart.js").
+        key_elements: 2-4 concise bullet points of what will be built.
+    """
+    elements = "\\n".join(f"  - {e}" for e in key_elements)
+    return f"Plan: {approach}\\nTech: {technology}\\n{elements}"`,
+    },
+    {
+      type: "markdown",
+      id: "da-system-prompt",
+      content: `## System Prompt
+
+The system prompt encodes the **mandatory visualization workflow** and quality standards:
+
+1. **Acknowledge** → **Plan** → **Build** → **Narrate** (never skip plan)
+2. \`<script type="module">\` is REQUIRED for import map usage
+3. 3D content MUST use Three.js with WebGL, PBR materials, multiple lights, OrbitControls
+4. Every visualization should be "polished and portfolio-ready"
+5. Always call \`query_data\` before showing charts
+6. Be brief about CopilotKit/LangGraph explanations (1-2 sentences)`,
+    },
+    {
+      type: "markdown",
+      id: "da-memory",
+      content: `## Bounded Memory
+
+The default LangGraph \`MemorySaver\` stores all conversation threads in memory forever — a problem on memory-constrained hosts (512MB). \`BoundedMemorySaver\` adds FIFO eviction:`,
+    },
+    {
+      type: "code",
+      id: "da-memory-code",
+      language: "python",
+      filename: "apps/agent/src/bounded_memory_saver.py",
+      content: `class BoundedMemorySaver(MemorySaver):
+    """MemorySaver that evicts oldest threads when exceeding max_threads."""
+
+    def __init__(self, max_threads: int = 200):
+        super().__init__()
+        self.max_threads = max_threads
+        self._insertion_order: OrderedDict[str, None] = OrderedDict()
+
+    def put(self, config, checkpoint, metadata, new_versions):
+        thread_id = config["configurable"]["thread_id"]
+        self._insertion_order[thread_id] = None
+        self._insertion_order.move_to_end(thread_id)  # LRU tracking
+
+        result = super().put(config, checkpoint, metadata, new_versions)
+
+        # Evict oldest threads when over limit
+        while len(self.storage) > self.max_threads:
+            oldest, _ = self._insertion_order.popitem(last=False)
+            if oldest in self.storage:
+                del self.storage[oldest]
+        return result`,
     },
     {
       type: "playground",
-      id: "hooks-playground",
-      title: "Try it: Simulated Agent Hooks",
+      id: "da-playground",
+      title: "Try it: Agent Tool Pipeline",
       files: {
-        "/App.js": `import { useState, useCallback } from "react";
+        "/App.js": `import { useState } from "react";
 
-// Simulating what useAgent() provides
-function useSimulatedAgent() {
-  const [state, setState] = useState({
-    todos: [
-      { id: "1", title: "Read the docs", emoji: "📖", status: "pending" },
-    ],
-    theme: "light",
-  });
-  const [isRunning, setIsRunning] = useState(false);
+// Simulate the mandatory visualization workflow:
+// Acknowledge → Plan → Build → Narrate
 
-  const simulateAgentAction = useCallback(async () => {
-    setIsRunning(true);
-    // Simulate agent thinking...
-    await new Promise(r => setTimeout(r, 1500));
-    setState(prev => ({
-      ...prev,
-      todos: [
-        ...prev.todos,
-        {
-          id: String(Date.now()),
-          title: "Agent-added task",
-          emoji: "🤖",
-          status: "pending",
-        },
+const steps = [
+  {
+    type: "acknowledge",
+    content: "I'll create a visualization showing the agent architecture.",
+  },
+  {
+    type: "tool_call",
+    tool: "plan_visualization",
+    args: {
+      approach: "Layered diagram showing data flow from user to agent to frontend",
+      technology: "inline SVG",
+      keyElements: [
+        "User input → CopilotKit runtime",
+        "LangGraph agent processes with tools",
+        "State syncs back to React frontend",
+        "Widget renderer displays result",
       ],
-    }));
-    setIsRunning(false);
-  }, []);
-
-  return { state, setState, isRunning, simulateAgentAction };
-}
+    },
+  },
+  {
+    type: "tool_call",
+    tool: "widgetRenderer",
+    args: { title: "Architecture Flow", description: "Agent data flow" },
+  },
+  {
+    type: "narrate",
+    content: "The diagram shows how a user message flows through CopilotKit to the LangGraph agent, which calls tools to update state, and the result syncs back to the frontend for rendering.",
+  },
+];
 
 export default function App() {
-  const { state, setState, isRunning, simulateAgentAction } = useSimulatedAgent();
+  const [current, setCurrent] = useState(-1);
+  const [running, setRunning] = useState(false);
 
-  const toggleTodo = (id) => {
-    setState(prev => ({
-      ...prev,
-      todos: prev.todos.map(t =>
-        t.id === id
-          ? { ...t, status: t.status === "completed" ? "pending" : "completed" }
-          : t
-      ),
-    }));
+  const runPipeline = async () => {
+    setRunning(true);
+    setCurrent(-1);
+    for (let i = 0; i < steps.length; i++) {
+      await new Promise(r => setTimeout(r, 1000));
+      setCurrent(i);
+    }
+    setRunning(false);
   };
 
   return (
-    <div style={{ fontFamily: "'Plus Jakarta Sans', sans-serif", padding: 20 }}>
-      <div style={{ display: "flex", alignItems: "center", gap: 12, marginBottom: 16 }}>
-        <h2 style={{ fontSize: 16, fontWeight: 700, margin: 0 }}>
-          Hook Simulation
-        </h2>
-        {isRunning && (
-          <span style={{
-            fontSize: 12, padding: "2px 8px", borderRadius: 12,
-            background: "#BEC2FF", color: "#4a4a8a", fontWeight: 600,
-          }}>
-            Agent working...
-          </span>
-        )}
-      </div>
-
-      <div style={{ marginBottom: 16 }}>
-        {state.todos.map(t => (
-          <div
-            key={t.id}
-            onClick={() => toggleTodo(t.id)}
-            style={{
-              padding: "10px 12px", marginBottom: 6, borderRadius: 8,
-              background: t.status === "completed" ? "#f0fdf4" : "#fff",
-              border: "1px solid #e5e7eb", cursor: "pointer", fontSize: 14,
-              textDecoration: t.status === "completed" ? "line-through" : "none",
-            }}
-          >
-            {t.emoji} {t.title}
-          </div>
-        ))}
-      </div>
-
-      <div style={{ display: "flex", gap: 8 }}>
-        <button
-          onClick={simulateAgentAction}
-          disabled={isRunning}
-          style={{
-            padding: "8px 16px", borderRadius: 8, border: "none",
-            background: isRunning ? "#d1d5db" : "#9599CC",
-            color: "#fff", cursor: isRunning ? "default" : "pointer",
-            fontWeight: 600, fontSize: 13,
-          }}
-        >
-          {isRunning ? "Thinking..." : "Simulate Agent Action"}
-        </button>
-        <button
-          onClick={() => setState(prev => ({
-            ...prev,
-            todos: [...prev.todos, {
-              id: String(Date.now()),
-              title: "User-added task",
-              emoji: "👤",
-              status: "pending",
-            }],
-          }))}
-          style={{
-            padding: "8px 16px", borderRadius: 8, fontWeight: 600,
-            background: "#85E0CE", color: "#0a4a3a", border: "none",
-            cursor: "pointer", fontSize: 13,
-          }}
-        >
-          User Adds Todo
-        </button>
-      </div>
-
-      <p style={{ fontSize: 12, color: "#9ca3af", marginTop: 12 }}>
-        Both buttons modify the same state — just like agent.setState() and user interactions do in the real app.
+    <div style={{ fontFamily: "system-ui, sans-serif", padding: 20 }}>
+      <h2 style={{ fontSize: 16, fontWeight: 700, marginBottom: 4 }}>
+        Mandatory Visualization Workflow
+      </h2>
+      <p style={{ fontSize: 13, color: "#6b7280", marginBottom: 16 }}>
+        Every visual response follows: Acknowledge → Plan → Build → Narrate
       </p>
+
+      <div style={{ display: "flex", flexDirection: "column", gap: 8, marginBottom: 16 }}>
+        {steps.map((step, i) => {
+          const active = i <= current;
+          const isCurrent = i === current;
+          return (
+            <div
+              key={i}
+              style={{
+                padding: 12, borderRadius: 8, fontSize: 13,
+                background: active ? (step.type === "tool_call" ? "#f5f3ff" : "#f9fafb") : "#fafafa",
+                border: \`1px solid \${isCurrent ? "#9599CC" : active ? "#e5e7eb" : "#f0f0f0"}\`,
+                opacity: active ? 1 : 0.4,
+                transition: "all 0.3s ease",
+              }}
+            >
+              <div style={{
+                fontSize: 11, fontWeight: 600, textTransform: "uppercase",
+                color: step.type === "tool_call" ? "#9599CC" : "#6b7280",
+                marginBottom: 4,
+              }}>
+                {step.type === "tool_call" ? \`🔧 \${step.tool}\` :
+                 step.type === "acknowledge" ? "💬 Acknowledge" :
+                 "📝 Narrate"}
+              </div>
+              {step.type === "tool_call" ? (
+                <pre style={{
+                  margin: 0, fontSize: 11, fontFamily: "monospace",
+                  color: "#374151", whiteSpace: "pre-wrap",
+                }}>
+                  {JSON.stringify(step.args, null, 2)}
+                </pre>
+              ) : (
+                <div style={{ color: "#374151" }}>{step.content}</div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      <button
+        onClick={runPipeline}
+        disabled={running}
+        style={{
+          padding: "8px 16px", borderRadius: 8, border: "none",
+          background: running ? "#d1d5db" : "#9599CC", color: "#fff",
+          cursor: running ? "default" : "pointer", fontWeight: 600, fontSize: 13,
+        }}
+      >
+        {running ? "Running pipeline..." : "Run Visualization Pipeline"}
+      </button>
     </div>
   );
 }`,

--- a/apps/notebook/src/content/chapters/04-copilotkit-hooks.ts
+++ b/apps/notebook/src/content/chapters/04-copilotkit-hooks.ts
@@ -1,0 +1,254 @@
+import type { Chapter } from "@/lib/types";
+
+export const copilotKitHooks: Chapter = {
+  id: "copilotkit-hooks",
+  title: "CopilotKit Hooks",
+  description:
+    "The React hooks that connect your frontend to the AI agent.",
+  icon: "🪝",
+  cells: [
+    {
+      type: "markdown",
+      id: "hooks-overview",
+      content: `# CopilotKit Hooks
+
+CopilotKit provides several React hooks that form the bridge between your frontend and the AI agent. Here's an overview of the key hooks used in OpenGenerativeUI:
+
+| Hook | Purpose |
+|------|---------|
+| \`useAgent()\` | Access agent state, send messages, check if agent is running |
+| \`useComponent()\` | Register a React component the agent can render in chat |
+| \`useFrontendTool()\` | Register a JS function the agent can call in the browser |
+| \`useRenderTool()\` | Register a tool that renders UI while executing |
+| \`useHumanInTheLoop()\` | Create async tools that pause for user input |`,
+    },
+    {
+      type: "markdown",
+      id: "hooks-useagent",
+      content: `## useAgent()
+
+The core hook. It gives you access to the agent's state and lets you interact with it:
+
+- \`agent.state\` — The current agent state (typed by your AgentState schema)
+- \`agent.setState()\` — Update the agent's state from the frontend
+- \`agent.isRunning\` — Whether the agent is currently processing
+- \`agent.sendMessage()\` — Send a message to the agent programmatically`,
+    },
+    {
+      type: "code",
+      id: "hooks-useagent-code",
+      language: "tsx",
+      filename: "Using useAgent()",
+      content: `import { useAgent } from "@copilotkit/react-core";
+
+function TodoCanvas() {
+  const { agent } = useAgent();
+
+  // Read state
+  const todos = agent.state?.todos || [];
+
+  // Write state (syncs to agent backend)
+  const addTodo = (todo) => {
+    agent.setState({ todos: [...todos, todo] });
+  };
+
+  // Check if agent is working
+  if (agent.isRunning) {
+    return <LoadingSpinner />;
+  }
+
+  return <TodoList todos={todos} onAdd={addTodo} />;
+}`,
+    },
+    {
+      type: "markdown",
+      id: "hooks-usecomponent",
+      content: `## useComponent()
+
+Registers a React component as a tool the agent can call. When the agent calls this tool, instead of returning text, CopilotKit renders your component inline in the chat with the agent-provided props:`,
+    },
+    {
+      type: "code",
+      id: "hooks-usecomponent-code",
+      language: "tsx",
+      filename: "Registering a component tool",
+      content: `import { useComponent } from "@copilotkit/react-core";
+import { z } from "zod";
+
+function MyChart({ title, data }) {
+  return (
+    <div>
+      <h3>{title}</h3>
+      {/* render chart with data */}
+    </div>
+  );
+}
+
+// In your hook setup:
+useComponent("myChart", {
+  component: MyChart,
+  schema: z.object({
+    title: z.string(),
+    data: z.array(z.object({
+      label: z.string(),
+      value: z.number(),
+    })),
+  }),
+  description: "Render a custom chart",
+});`,
+    },
+    {
+      type: "markdown",
+      id: "hooks-usefrontendtool",
+      content: `## useFrontendTool()
+
+Registers a JavaScript function that the agent can call to perform actions in the browser. Unlike \`useComponent()\`, this doesn't render UI — it executes logic:`,
+    },
+    {
+      type: "code",
+      id: "hooks-usefrontendtool-code",
+      language: "tsx",
+      filename: "Frontend tool: theme toggle",
+      content: `import { useFrontendTool } from "@copilotkit/react-core";
+
+useFrontendTool("toggleTheme", {
+  description: "Toggle between light and dark theme",
+  schema: z.object({
+    theme: z.enum(["light", "dark"]).describe("The theme to switch to"),
+  }),
+  handler: ({ theme }) => {
+    document.documentElement.classList.remove("light", "dark");
+    document.documentElement.classList.add(theme);
+    return \`Switched to \${theme} mode\`;
+  },
+});`,
+    },
+    {
+      type: "playground",
+      id: "hooks-playground",
+      title: "Try it: Simulated Agent Hooks",
+      files: {
+        "/App.js": `import { useState, useCallback } from "react";
+
+// Simulating what useAgent() provides
+function useSimulatedAgent() {
+  const [state, setState] = useState({
+    todos: [
+      { id: "1", title: "Read the docs", emoji: "📖", status: "pending" },
+    ],
+    theme: "light",
+  });
+  const [isRunning, setIsRunning] = useState(false);
+
+  const simulateAgentAction = useCallback(async () => {
+    setIsRunning(true);
+    // Simulate agent thinking...
+    await new Promise(r => setTimeout(r, 1500));
+    setState(prev => ({
+      ...prev,
+      todos: [
+        ...prev.todos,
+        {
+          id: String(Date.now()),
+          title: "Agent-added task",
+          emoji: "🤖",
+          status: "pending",
+        },
+      ],
+    }));
+    setIsRunning(false);
+  }, []);
+
+  return { state, setState, isRunning, simulateAgentAction };
+}
+
+export default function App() {
+  const { state, setState, isRunning, simulateAgentAction } = useSimulatedAgent();
+
+  const toggleTodo = (id) => {
+    setState(prev => ({
+      ...prev,
+      todos: prev.todos.map(t =>
+        t.id === id
+          ? { ...t, status: t.status === "completed" ? "pending" : "completed" }
+          : t
+      ),
+    }));
+  };
+
+  return (
+    <div style={{ fontFamily: "'Plus Jakarta Sans', sans-serif", padding: 20 }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 12, marginBottom: 16 }}>
+        <h2 style={{ fontSize: 16, fontWeight: 700, margin: 0 }}>
+          Hook Simulation
+        </h2>
+        {isRunning && (
+          <span style={{
+            fontSize: 12, padding: "2px 8px", borderRadius: 12,
+            background: "#BEC2FF", color: "#4a4a8a", fontWeight: 600,
+          }}>
+            Agent working...
+          </span>
+        )}
+      </div>
+
+      <div style={{ marginBottom: 16 }}>
+        {state.todos.map(t => (
+          <div
+            key={t.id}
+            onClick={() => toggleTodo(t.id)}
+            style={{
+              padding: "10px 12px", marginBottom: 6, borderRadius: 8,
+              background: t.status === "completed" ? "#f0fdf4" : "#fff",
+              border: "1px solid #e5e7eb", cursor: "pointer", fontSize: 14,
+              textDecoration: t.status === "completed" ? "line-through" : "none",
+            }}
+          >
+            {t.emoji} {t.title}
+          </div>
+        ))}
+      </div>
+
+      <div style={{ display: "flex", gap: 8 }}>
+        <button
+          onClick={simulateAgentAction}
+          disabled={isRunning}
+          style={{
+            padding: "8px 16px", borderRadius: 8, border: "none",
+            background: isRunning ? "#d1d5db" : "#9599CC",
+            color: "#fff", cursor: isRunning ? "default" : "pointer",
+            fontWeight: 600, fontSize: 13,
+          }}
+        >
+          {isRunning ? "Thinking..." : "Simulate Agent Action"}
+        </button>
+        <button
+          onClick={() => setState(prev => ({
+            ...prev,
+            todos: [...prev.todos, {
+              id: String(Date.now()),
+              title: "User-added task",
+              emoji: "👤",
+              status: "pending",
+            }],
+          }))}
+          style={{
+            padding: "8px 16px", borderRadius: 8, fontWeight: 600,
+            background: "#85E0CE", color: "#0a4a3a", border: "none",
+            cursor: "pointer", fontSize: 13,
+          }}
+        >
+          User Adds Todo
+        </button>
+      </div>
+
+      <p style={{ fontSize: 12, color: "#9ca3af", marginTop: 12 }}>
+        Both buttons modify the same state — just like agent.setState() and user interactions do in the real app.
+      </p>
+    </div>
+  );
+}`,
+      },
+    },
+  ],
+};

--- a/apps/notebook/src/content/chapters/05-frontend-tools.ts
+++ b/apps/notebook/src/content/chapters/05-frontend-tools.ts
@@ -14,316 +14,344 @@ export const mcpSkills: Chapter = {
 
 The agent's visual quality comes from **skill documents** — composable \`.txt\` playbooks that define design rules, component patterns, and rendering techniques.
 
-Skills are served through an **MCP (Model Context Protocol) server**, making them accessible to both the LangGraph agent and external AI tools like Claude Desktop.
-
-## Skill Architecture
-
-\`\`\`
-apps/mcp/
-├── skills/
-│   ├── master-agent-playbook.txt    # Core philosophy, response patterns
-│   ├── svg-diagram-skill.txt        # SVG setup, typography, color ramps
-│   └── agent-skills-vol2.txt        # Advanced design system, UI mockups
-└── src/
-    ├── server.ts    # MCP server (resources, prompts, tools)
-    ├── skills.ts    # Skill file loader
-    └── renderer.ts  # HTML document assembly with design system
-\`\`\`
-
-The agent also has a local \`skills/\` directory loaded via \`create_deep_agent(skills=[...])\` — these are loaded at agent startup and available as contextual instructions.`,
-    },
-    {
-      type: "markdown",
-      id: "skills-mcp-server",
-      content: `## MCP Server
-
-The MCP server exposes skills in three ways:
-
-| MCP concept | Name | What it provides |
-|-------------|------|-----------------|
-| **Resource** | \`skills://list\` | JSON array of available skill names |
-| **Resource** | \`skills://{name}\` | Full text of a specific skill |
-| **Prompt** | \`create_widget\` | master-agent-playbook.txt as a pre-composed prompt |
-| **Prompt** | \`create_svg_diagram\` | svg-diagram-skill.txt |
-| **Prompt** | \`create_visualization\` | agent-skills-vol2.txt |
-| **Tool** | \`assemble_document\` | Wraps raw HTML with the full design system CSS/JS |`,
+Skills are served through an **MCP (Model Context Protocol) server**, making them accessible to both the LangGraph agent and external AI tools like Claude Desktop.`,
     },
     {
       type: "code",
       id: "skills-server-code",
       language: "typescript",
-      filename: "apps/mcp/src/server.ts",
-      content: `import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { listSkills, loadSkill } from "./skills.js";
-import { assembleDocument } from "./renderer.js";
-
-export function createMcpServer(): McpServer {
-  const server = new McpServer({
-    name: "open-generative-ui",
-    version: "0.1.0",
-  });
+      filename: "apps/mcp/src/server.ts (simplified)",
+      content: `export function createMcpServer(): McpServer {
+  const server = new McpServer({ name: "open-generative-ui", version: "0.1.0" });
 
   // Resources: list and read skill documents
-  server.registerResource("skills-list", "skills://list", {
-    description: "JSON array of available skill names",
-    mimeType: "application/json",
-  }, async () => ({
-    contents: [{ uri: "skills://list", text: JSON.stringify(listSkills()) }],
-  }));
-
-  server.registerResource("skill",
-    new ResourceTemplate("skills://{name}", { /* ... */ }),
-    { description: "Full text of a skill document" },
-    async (uri, { name }) => ({
-      contents: [{ uri: uri.href, text: loadSkill(name as string) }],
-    })
-  );
+  server.registerResource("skills-list", "skills://list", { ... });
+  server.registerResource("skill", new ResourceTemplate("skills://{name}"), { ... });
 
   // Prompts: pre-composed skill instructions
-  server.registerPrompt("create_widget", {
-    description: "Instructions for creating interactive HTML widgets",
-  }, async () => ({
-    messages: [{ role: "user", content: {
-      type: "text", text: loadSkill("master-agent-playbook")
-    }}],
-  }));
+  server.registerPrompt("create_widget", { ... });       // master-agent-playbook
+  server.registerPrompt("create_svg_diagram", { ... });   // svg-diagram-skill
+  server.registerPrompt("create_visualization", { ... }); // agent-skills-vol2
 
   // Tool: wrap HTML with the full design system
   server.registerTool("assemble_document", {
-    description: "Wraps HTML with theme CSS, SVG classes, form styles, and bridge JS",
-    inputSchema: {
-      title: z.string(),
-      description: z.string(),
-      html: z.string().describe("Self-contained HTML fragment"),
-    },
+    inputSchema: { title, description, html },
   }, async ({ html }) => ({
     content: [{ type: "text", text: assembleDocument(html) }],
   }));
-
-  return server;
 }`,
     },
     {
       type: "markdown",
-      id: "skills-playbook",
-      content: `## Master Agent Playbook
+      id: "skills-design-system",
+      content: `## Design System Tokens
 
-The core skill document defines the agent's **response philosophy** and **decision tree**:
-
-**"Show, don't tell"** — the agent prioritizes visuals over text.
-
-### Response Decision Tree
-
-| User asks about... | Agent produces... |
-|---------------------|-------------------|
-| Quick fact | 1-2 sentences of text |
-| Concept / visual | SVG diagram |
-| Process / flow | Flowchart or stepper |
-| Data-driven question | Interactive chart |
-| Abstract / explorable | Interactive widget |
-| Working code | Running artifact |
-| Comparison | Side-by-side visual |
-
-### 3-Layer Response Pattern
-
-Every visual response uses:
-1. **Hook** (1-2 sentences) — Validate the question, set context
-2. **Visual** — The core explanation as a rendered component
-3. **Narration** (2-4 paragraphs) — Walk through the visual, offer to go deeper`,
-    },
-    {
-      type: "markdown",
-      id: "skills-svg",
-      content: `## SVG Diagram Skill
-
-Defines precise rules for hand-drawn SVG diagrams:
-
-- **ViewBox**: Always 680px wide, height = bottom element y + height + 40px
-- **Typography**: 14px titles, 12px subtitles, weights 400/500 only, sentence case
-- **Text width estimation**: 14px = 8px/char, 12px = 7px/char, +48px padding
-- **9 color ramps**: Teal, Purple, Coral, Pink, Gray, Blue, Green, Amber, Red — each with light/dark variants
-- **Node heights**: Single-line = 44px, two-line = 56px
-- **Arrows**: stroke-width 1.5px, marker-end, never cross boxes
-- **Critical checks**: ViewBox height correct, text fits rectangles, all paths have fill="none"`,
-    },
-    {
-      type: "markdown",
-      id: "skills-vol2",
-      content: `## Advanced Skills (Vol. 2)
-
-The advanced skill document adds a **full design system** with CSS variables:
-
-\`\`\`
---color-background-primary/secondary/tertiary/info/danger/success/warning
---color-text-primary/secondary/tertiary/info/danger/success/warning
---color-border-primary/secondary/tertiary/info/danger/success/warning
---font-sans/serif/mono
---border-radius-md(8px)/lg(12px)/xl(16px)
-\`\`\`
-
-**Key rules**:
-- Typography: h1=22px, h2=18px, h3=16px, body=16px, all weight 500 max
-- Borders: 0.5px solid with tertiary border color
-- Cards: primary background, tertiary border, lg radius, 1rem padding
-- **Explicitly banned**: Gradients, shadows, blur, glow, neon, emoji
-- Min font-size: 11px`,
-    },
-    {
-      type: "code",
-      id: "skills-renderer",
-      language: "typescript",
-      filename: "apps/mcp/src/renderer.ts — assembleDocument (simplified)",
-      content: `// The assemble_document tool wraps agent HTML with:
-// 1. Theme CSS — light/dark mode variables
-// 2. SVG Classes — .c-purple, .c-teal, .c-blue, etc.
-// 3. Form Styles — native-looking buttons, inputs, sliders
-// 4. Bridge JS — sendPrompt(), openLink(), auto-resize
-
-export function assembleDocument(html: string): string {
-  return \`<!DOCTYPE html>
-<html>
-<head>
-  <style>\${THEME_CSS}</style>
-  <style>\${SVG_CLASSES_CSS}</style>
-  <style>\${FORM_STYLES_CSS}</style>
-</head>
-<body>
-  \${html}
-  <script>\${BRIDGE_JS}</script>
-</body>
-</html>\`;
-}
-
-// WARNING: Keep in sync with widget-renderer.tsx
-// when the design system changes.`,
+The skill documents define a full token set that gets injected into every widget iframe. The playground below is a **live token explorer** — it renders real HTML using the same CSS variables the agent uses:`,
     },
     {
       type: "playground",
-      id: "skills-playground",
-      title: "Try it: Skill-Guided SVG Diagram",
+      id: "skills-tokens-playground",
+      title: "Live: Design system token explorer with real rendering",
+      files: {
+        "/App.js": `import { useState, useRef, useEffect } from "react";
+
+// These are the actual CSS variables from renderer.ts
+const THEME_CSS = \`
+:root {
+  --color-background-primary: #ffffff;
+  --color-background-secondary: #f7f6f3;
+  --color-background-tertiary: #efeee9;
+  --color-background-info: #E6F1FB;
+  --color-background-danger: #FCEBEB;
+  --color-background-success: #EAF3DE;
+  --color-background-warning: #FAEEDA;
+  --color-text-primary: #1a1a1a;
+  --color-text-secondary: #73726c;
+  --color-text-tertiary: #9c9a92;
+  --color-text-info: #185FA5;
+  --color-text-danger: #A32D2D;
+  --color-text-success: #3B6D11;
+  --color-text-warning: #854F0B;
+  --color-border-tertiary: rgba(0, 0, 0, 0.15);
+  --font-sans: system-ui, -apple-system, sans-serif;
+  --border-radius-md: 8px;
+  --border-radius-lg: 12px;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-background-primary: #1a1a18;
+    --color-background-secondary: #2c2c2a;
+    --color-text-primary: #e8e6de;
+    --color-text-secondary: #9c9a92;
+    --color-border-tertiary: rgba(255, 255, 255, 0.15);
+  }
+}
+body { font-family: var(--font-sans); margin: 0; padding: 16px;
+  background: var(--color-background-primary); color: var(--color-text-primary); }
+\`;
+
+// Templates the user can switch between
+const templates = {
+  "Status cards": \`<div style="display:grid;grid-template-columns:repeat(3,1fr);gap:12px">
+  <div style="padding:14px;border-radius:var(--border-radius-lg);background:var(--color-background-success);border:0.5px solid var(--color-border-tertiary)">
+    <div style="font-size:11px;color:var(--color-text-success)">Healthy</div>
+    <div style="font-size:22px;font-weight:500;color:var(--color-text-success)">12 services</div>
+  </div>
+  <div style="padding:14px;border-radius:var(--border-radius-lg);background:var(--color-background-warning);border:0.5px solid var(--color-border-tertiary)">
+    <div style="font-size:11px;color:var(--color-text-warning)">Degraded</div>
+    <div style="font-size:22px;font-weight:500;color:var(--color-text-warning)">2 services</div>
+  </div>
+  <div style="padding:14px;border-radius:var(--border-radius-lg);background:var(--color-background-danger);border:0.5px solid var(--color-border-tertiary)">
+    <div style="font-size:11px;color:var(--color-text-danger)">Down</div>
+    <div style="font-size:22px;font-weight:500;color:var(--color-text-danger)">0 services</div>
+  </div>
+</div>\`,
+  "Info panel": \`<div style="padding:16px;border-radius:var(--border-radius-lg);background:var(--color-background-info);border:0.5px solid var(--color-border-tertiary)">
+  <div style="font-size:14px;font-weight:500;color:var(--color-text-info);margin-bottom:6px">How the design system works</div>
+  <div style="font-size:13px;color:var(--color-text-info);line-height:1.6">
+    Every widget gets these CSS variables injected automatically. Use <code style="background:rgba(0,0,0,0.06);padding:1px 4px;border-radius:3px">var(--color-text-primary)</code> instead of hardcoded colors and your widgets will support dark mode for free.
+  </div>
+</div>\`,
+  "Data table": \`<table style="width:100%;border-collapse:collapse;font-size:13px">
+  <thead>
+    <tr style="border-bottom:0.5px solid var(--color-border-tertiary)">
+      <th style="text-align:left;padding:8px;color:var(--color-text-tertiary);font-weight:500">Tool</th>
+      <th style="text-align:right;padding:8px;color:var(--color-text-tertiary);font-weight:500">Calls</th>
+      <th style="text-align:right;padding:8px;color:var(--color-text-tertiary);font-weight:500">Avg ms</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr style="border-bottom:0.5px solid var(--color-border-tertiary)">
+      <td style="padding:8px;color:var(--color-text-primary)">widgetRenderer</td>
+      <td style="text-align:right;padding:8px;color:var(--color-text-primary);font-weight:500">847</td>
+      <td style="text-align:right;padding:8px;color:var(--color-text-success)">280</td>
+    </tr>
+    <tr style="border-bottom:0.5px solid var(--color-border-tertiary)">
+      <td style="padding:8px;color:var(--color-text-primary)">manage_todos</td>
+      <td style="text-align:right;padding:8px;color:var(--color-text-primary);font-weight:500">312</td>
+      <td style="text-align:right;padding:8px;color:var(--color-text-success)">45</td>
+    </tr>
+    <tr>
+      <td style="padding:8px;color:var(--color-text-primary)">plan_visualization</td>
+      <td style="text-align:right;padding:8px;color:var(--color-text-primary);font-weight:500">823</td>
+      <td style="text-align:right;padding:8px;color:var(--color-text-warning)">520</td>
+    </tr>
+  </tbody>
+</table>\`,
+};
+
+export default function App() {
+  const [selected, setSelected] = useState("Status cards");
+  const iframeRef = useRef(null);
+
+  useEffect(() => {
+    if (!iframeRef.current) return;
+    const doc = iframeRef.current.contentDocument;
+    if (!doc) return;
+    doc.open();
+    doc.write(\`<!DOCTYPE html><html><head><style>\${THEME_CSS}</style></head><body>\${templates[selected]}</body></html>\`);
+    doc.close();
+  }, [selected]);
+
+  return (
+    <div style={{ fontFamily: "system-ui, sans-serif" }}>
+      {/* Template selector */}
+      <div style={{ padding: "10px 16px", borderBottom: "1px solid #e5e7eb", display: "flex", gap: 6 }}>
+        {Object.keys(templates).map(name => (
+          <button key={name} onClick={() => setSelected(name)} style={{
+            padding: "5px 12px", borderRadius: 6, border: "none", fontSize: 12, fontWeight: 600, cursor: "pointer",
+            background: selected === name ? "#5B3FA0" : "#f0f0f0",
+            color: selected === name ? "#fff" : "#6b7280",
+          }}>
+            {name}
+          </button>
+        ))}
+      </div>
+
+      {/* Live rendered preview using the REAL design system CSS */}
+      <iframe
+        ref={iframeRef}
+        sandbox="allow-scripts"
+        style={{ width: "100%", height: 160, border: "none", display: "block" }}
+      />
+
+      {/* Show the HTML source */}
+      <div style={{ borderTop: "1px solid #e5e7eb", padding: 12, background: "#f9fafb" }}>
+        <div style={{ fontSize: 10, fontWeight: 600, color: "#6b7280", textTransform: "uppercase", marginBottom: 4 }}>HTML using design system tokens:</div>
+        <pre style={{ margin: 0, fontSize: 11, fontFamily: "monospace", color: "#374151", whiteSpace: "pre-wrap", maxHeight: 120, overflow: "auto", lineHeight: 1.5 }}>
+          {templates[selected].trim()}
+        </pre>
+      </div>
+    </div>
+  );
+}`,
+      },
+    },
+    {
+      type: "markdown",
+      id: "skills-svg-rules",
+      content: `## SVG Diagram Skill
+
+The SVG skill defines precise rules for hand-drawn diagrams. The playground below implements these rules as a live diagram builder — add nodes, pick colors from the 9-ramp palette, and watch the SVG follow the viewBox/spacing rules:`,
+    },
+    {
+      type: "playground",
+      id: "skills-svg-playground",
+      title: "Live: SVG diagram builder following skill rules",
       files: {
         "/App.js": `import { useState } from "react";
 
-// This demonstrates the SVG diagram skill rules:
-// - ViewBox 680px wide, responsive
-// - 14px titles, 12px subtitles
-// - 9 color ramps with light/dark variants
-// - Proper text width estimation
+// Implements the actual SVG diagram skill rules:
+// - ViewBox 680px wide, responsive via width="100%"
+// - 14px titles (8px/char), 12px subtitles (7px/char), +48px padding
+// - Two-line nodes: 56px tall, single-line: 44px tall
+// - Arrow markers, stroke-width 1.5px
+// - 9 color ramps from the skill document
 
-const colors = {
+const ramps = {
   teal:   { fill: "#E1F5EE", stroke: "#0F6E56", text: "#085041" },
   purple: { fill: "#EDE9F5", stroke: "#5B3FA0", text: "#3E2B6F" },
   coral:  { fill: "#FCE8E8", stroke: "#C44D4D", text: "#8A2E2E" },
+  pink:   { fill: "#FAEAF3", stroke: "#B54A8C", text: "#7E3362" },
+  gray:   { fill: "#F1F1F0", stroke: "#73726C", text: "#474745" },
   blue:   { fill: "#E3EFFC", stroke: "#2663B3", text: "#1A4680" },
+  green:  { fill: "#E1F5EE", stroke: "#2D8B5F", text: "#1D5C3F" },
   amber:  { fill: "#FEF3DC", stroke: "#B8860B", text: "#7A5A07" },
+  red:    { fill: "#FCEBEB", stroke: "#C44D4D", text: "#8A2E2E" },
 };
 
-function DiagramBuilder() {
+export default function App() {
   const [nodes, setNodes] = useState([
-    { id: 1, label: "User Input", sub: "Chat message", color: "teal", x: 250, y: 40 },
-    { id: 2, label: "CopilotKit Runtime", sub: "API route", color: "purple", x: 250, y: 130 },
-    { id: 3, label: "LangGraph Agent", sub: "Tools + state", color: "blue", x: 250, y: 220 },
-    { id: 4, label: "Widget Renderer", sub: "Sandboxed iframe", color: "coral", x: 250, y: 310 },
+    { id: 1, label: "User message", sub: "Chat input", color: "teal" },
+    { id: 2, label: "CopilotKit runtime", sub: "API route → LangGraph", color: "purple" },
+    { id: 3, label: "Deep agent", sub: "Tools + middleware", color: "blue" },
+    { id: 4, label: "Widget renderer", sub: "Sandboxed iframe", color: "coral" },
   ]);
-
-  const [selectedColor, setSelectedColor] = useState("teal");
+  const [selectedRamp, setSelectedRamp] = useState("teal");
+  const [newLabel, setNewLabel] = useState("");
+  const [newSub, setNewSub] = useState("");
 
   const addNode = () => {
-    const lastY = nodes.length > 0 ? nodes[nodes.length - 1].y : -50;
-    setNodes([...nodes, {
-      id: Date.now(),
-      label: "New Node",
-      sub: "Description",
-      color: selectedColor,
-      x: 250,
-      y: lastY + 90,
+    if (!newLabel) return;
+    setNodes(prev => [...prev, {
+      id: Date.now(), label: newLabel || "Node", sub: newSub || "", color: selectedRamp,
     }]);
+    setNewLabel("");
+    setNewSub("");
   };
 
-  const svgHeight = nodes.length > 0
-    ? nodes[nodes.length - 1].y + 56 + 40  // last y + node height + padding
-    : 100;
+  const removeNode = (id) => setNodes(prev => prev.filter(n => n.id !== id));
+
+  // Calculate layout following skill rules
+  const padding = 40;
+  const gap = 34;
+  const nodePositions = nodes.map((node, i) => {
+    const hasSub = !!node.sub;
+    const h = hasSub ? 56 : 44;
+    const titleW = node.label.length * 8;   // 14px = 8px/char
+    const subW = node.sub ? node.sub.length * 7 : 0;  // 12px = 7px/char
+    const w = Math.max(titleW, subW) + 48;  // +48px padding
+    const y = i === 0 ? padding : null; // computed below
+    return { ...node, h, w, titleW, subW };
+  });
+
+  // Compute y positions
+  let currentY = padding;
+  nodePositions.forEach((n, i) => {
+    n.y = currentY;
+    n.x = 340 - n.w / 2; // center in 680px
+    currentY += n.h + gap;
+  });
+
+  const svgH = nodePositions.length > 0
+    ? nodePositions[nodePositions.length - 1].y + nodePositions[nodePositions.length - 1].h + padding
+    : 120;
 
   return (
-    <div style={{ fontFamily: "system-ui, sans-serif", padding: 20 }}>
-      <h2 style={{ fontSize: 16, fontWeight: 700, marginBottom: 12 }}>
-        SVG Diagram Skill Rules
-      </h2>
-
-      <svg width="100%" viewBox={\`0 0 680 \${svgHeight}\`} xmlns="http://www.w3.org/2000/svg">
-        {/* Arrow marker */}
+    <div style={{ fontFamily: "system-ui, sans-serif", padding: 16 }}>
+      {/* Live SVG output */}
+      <svg width="100%" viewBox={\`0 0 680 \${svgH}\`} xmlns="http://www.w3.org/2000/svg"
+        style={{ background: "#fff", borderRadius: 8, border: "1px solid #e5e7eb" }}>
         <defs>
-          <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5"
-            markerWidth="6" markerHeight="6" orient="auto-start-reverse">
-            <path d="M2 1L8 5L2 9" fill="none" stroke="context-stroke"
-              strokeWidth="1.5" strokeLinecap="round" />
+          <marker id="arr" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+            <path d="M2 1L8 5L2 9" fill="none" stroke="context-stroke" strokeWidth="1.5" strokeLinecap="round" />
           </marker>
         </defs>
-
-        {/* Connectors */}
-        {nodes.slice(1).map((node, i) => {
-          const prev = nodes[i];
-          return (
-            <line key={\`arrow-\${i}\`}
-              x1={prev.x + 90} y1={prev.y + 56}
-              x2={node.x + 90} y2={node.y}
-              stroke="#9ca3af" strokeWidth="1.5"
-              markerEnd="url(#arrow)"
-            />
-          );
+        {/* Arrows */}
+        {nodePositions.slice(1).map((n, i) => {
+          const prev = nodePositions[i];
+          return <line key={"a"+i} x1={prev.x + prev.w/2} y1={prev.y + prev.h}
+            x2={n.x + n.w/2} y2={n.y} stroke="#9c9a92" strokeWidth="1.5" markerEnd="url(#arr)" />;
         })}
-
         {/* Nodes */}
-        {nodes.map(node => {
-          const c = colors[node.color];
-          // Text width: 14px = 8px/char, 12px = 7px/char, +48px padding
-          const titleW = node.label.length * 8;
-          const subW = node.sub.length * 7;
-          const w = Math.max(titleW, subW) + 48;
+        {nodePositions.map(n => {
+          const c = ramps[n.color];
           return (
-            <g key={node.id}>
-              <rect x={node.x} y={node.y} width={w} height={56}
-                rx="8" fill={c.fill} stroke={c.stroke} strokeWidth="1" />
-              <text x={node.x + w/2} y={node.y + 22}
-                textAnchor="middle" dominantBaseline="central"
-                style={{ fontSize: 14, fontWeight: 500, fill: c.text }}>
-                {node.label}
-              </text>
-              <text x={node.x + w/2} y={node.y + 40}
-                textAnchor="middle" dominantBaseline="central"
-                style={{ fontSize: 12, fill: c.text, opacity: 0.7 }}>
-                {node.sub}
-              </text>
+            <g key={n.id}>
+              <rect x={n.x} y={n.y} width={n.w} height={n.h} rx="8" fill={c.fill} stroke={c.stroke} strokeWidth="1" />
+              <text x={n.x + n.w/2} y={n.y + (n.sub ? 22 : n.h/2)} textAnchor="middle" dominantBaseline="central"
+                style={{ fontSize: 14, fontWeight: 500, fill: c.text }}>{n.label}</text>
+              {n.sub && <text x={n.x + n.w/2} y={n.y + 40} textAnchor="middle" dominantBaseline="central"
+                style={{ fontSize: 12, fill: c.text, opacity: 0.7 }}>{n.sub}</text>}
             </g>
           );
         })}
       </svg>
 
-      <div style={{ display: "flex", gap: 8, marginTop: 12, alignItems: "center" }}>
-        {Object.keys(colors).map(c => (
-          <button key={c} onClick={() => setSelectedColor(c)} style={{
-            width: 28, height: 28, borderRadius: 6,
-            background: colors[c].fill, border: \`2px solid \${selectedColor === c ? colors[c].stroke : "transparent"}\`,
-            cursor: "pointer",
-          }} title={c} />
-        ))}
-        <button onClick={addNode} style={{
-          padding: "6px 14px", borderRadius: 8, border: "none",
-          background: "#9599CC", color: "#fff", cursor: "pointer",
-          fontWeight: 600, fontSize: 12,
-        }}>
-          + Add Node
-        </button>
+      <div style={{ fontSize: 10, color: "#9c9a92", marginTop: 4, fontFamily: "monospace" }}>
+        viewBox="0 0 680 {svgH}" | {nodes.length} nodes | Height = lastY({nodePositions.length > 0 ? nodePositions[nodePositions.length-1].y : 0}) + nodeH({nodePositions.length > 0 ? nodePositions[nodePositions.length-1].h : 0}) + pad(40)
       </div>
 
-      <p style={{ fontSize: 11, color: "#9ca3af", marginTop: 8 }}>
-        ViewBox: 680 x {svgHeight} | Nodes: 56px tall | Text: 14px/12px | Width = max(chars x 8, chars x 7) + 48
-      </p>
+      {/* Controls */}
+      <div style={{ marginTop: 12, display: "flex", gap: 8, flexWrap: "wrap", alignItems: "end" }}>
+        <div>
+          <div style={{ fontSize: 10, color: "#6b7280", marginBottom: 2 }}>Label</div>
+          <input value={newLabel} onChange={e => setNewLabel(e.target.value)} placeholder="Node title"
+            style={{ padding: "5px 8px", borderRadius: 6, border: "1px solid #d1d5db", fontSize: 12, width: 120 }} />
+        </div>
+        <div>
+          <div style={{ fontSize: 10, color: "#6b7280", marginBottom: 2 }}>Subtitle</div>
+          <input value={newSub} onChange={e => setNewSub(e.target.value)} placeholder="Optional"
+            style={{ padding: "5px 8px", borderRadius: 6, border: "1px solid #d1d5db", fontSize: 12, width: 100 }} />
+        </div>
+        <div>
+          <div style={{ fontSize: 10, color: "#6b7280", marginBottom: 2 }}>Color ramp</div>
+          <div style={{ display: "flex", gap: 3 }}>
+            {Object.keys(ramps).map(r => (
+              <button key={r} onClick={() => setSelectedRamp(r)} title={r} style={{
+                width: 18, height: 18, borderRadius: 4, border: selectedRamp === r ? \`2px solid \${ramps[r].stroke}\` : "1px solid #d1d5db",
+                background: ramps[r].fill, cursor: "pointer", padding: 0,
+              }} />
+            ))}
+          </div>
+        </div>
+        <button onClick={addNode} style={{
+          padding: "5px 12px", borderRadius: 6, border: "none", background: "#5B3FA0",
+          color: "#fff", cursor: "pointer", fontWeight: 600, fontSize: 12, alignSelf: "end",
+        }}>+ Add</button>
+      </div>
+
+      {/* Node list with remove */}
+      {nodes.length > 0 && (
+        <div style={{ marginTop: 8, display: "flex", gap: 4, flexWrap: "wrap" }}>
+          {nodes.map(n => (
+            <span key={n.id} style={{
+              padding: "2px 8px", borderRadius: 4, fontSize: 11,
+              background: ramps[n.color].fill, color: ramps[n.color].text,
+              border: \`1px solid \${ramps[n.color].stroke}\`, display: "flex", alignItems: "center", gap: 4,
+            }}>
+              {n.label}
+              <button onClick={() => removeNode(n.id)} style={{
+                background: "none", border: "none", cursor: "pointer", padding: 0,
+                fontSize: 12, color: ramps[n.color].text, opacity: 0.6, lineHeight: 1,
+              }}>x</button>
+            </span>
+          ))}
+        </div>
+      )}
     </div>
   );
-}
-
-export default DiagramBuilder;`,
+}`,
       },
     },
   ],

--- a/apps/notebook/src/content/chapters/05-frontend-tools.ts
+++ b/apps/notebook/src/content/chapters/05-frontend-tools.ts
@@ -1,0 +1,221 @@
+import type { Chapter } from "@/lib/types";
+
+export const frontendTools: Chapter = {
+  id: "frontend-tools",
+  title: "Frontend Tools",
+  description:
+    "How the agent calls JavaScript functions in the browser.",
+  icon: "🛠",
+  cells: [
+    {
+      type: "markdown",
+      id: "tools-concept",
+      content: `# Frontend Tools
+
+Frontend tools let the agent **execute JavaScript in the browser**. This is different from component tools (which render UI) — frontend tools perform actions like:
+
+- Toggling theme (light/dark mode)
+- Navigating to a page
+- Triggering animations
+- Reading browser state (viewport size, scroll position)
+- Modifying DOM elements
+
+The agent sees these tools in its tool list and can call them as needed during a conversation.`,
+    },
+    {
+      type: "code",
+      id: "tools-toggle-theme",
+      language: "tsx",
+      filename: "apps/app/src/hooks/use-generative-ui-examples.tsx — toggleTheme",
+      content: `import { useFrontendTool } from "@copilotkit/react-core";
+import { z } from "zod";
+import { useTheme } from "@/hooks/use-theme";
+
+// Inside the hook setup function:
+const { setTheme } = useTheme();
+
+useFrontendTool("toggleTheme", {
+  description: "Toggle between light and dark mode",
+  schema: z.object({
+    theme: z.enum(["light", "dark"]),
+  }),
+  handler: ({ theme }) => {
+    setTheme(theme);
+    return \`Theme switched to \${theme}\`;
+  },
+});`,
+    },
+    {
+      type: "markdown",
+      id: "tools-render",
+      content: `## Render Tools (useRenderTool)
+
+Sometimes you want a tool that **both executes logic AND renders UI** while it runs. \`useRenderTool()\` shows a component during tool execution — perfect for progress indicators, previews, or step-by-step visualizations:`,
+    },
+    {
+      type: "code",
+      id: "tools-render-code",
+      language: "tsx",
+      filename: "Plan visualization render tool",
+      content: `import { useRenderTool } from "@copilotkit/react-core";
+import { PlanCard } from "../components/generative-ui/plan-card";
+
+useRenderTool("plan_visualization", {
+  description: "Show planning progress to the user",
+  schema: z.object({
+    status: z.string(),
+    approach: z.string(),
+    technology: z.string(),
+    keyElements: z.array(z.string()),
+  }),
+  component: PlanCard,
+  // Tool can also return data to the agent
+  handler: (props) => \`Plan displayed: \${props.approach}\`,
+});`,
+    },
+    {
+      type: "playground",
+      id: "tools-playground",
+      title: "Try it: Frontend Tool Simulation",
+      files: {
+        "/App.js": `import { useState } from "react";
+
+// Simulating frontend tools the agent can call
+const tools = {
+  toggleTheme: {
+    description: "Toggle between light and dark mode",
+    handler: (args, setState) => {
+      setState(prev => ({ ...prev, theme: args.theme }));
+      return \`Switched to \${args.theme} mode\`;
+    },
+  },
+  setBackground: {
+    description: "Change the background color",
+    handler: (args, setState) => {
+      setState(prev => ({ ...prev, bgColor: args.color }));
+      return \`Background set to \${args.color}\`;
+    },
+  },
+  addNotification: {
+    description: "Show a notification to the user",
+    handler: (args, setState) => {
+      setState(prev => ({
+        ...prev,
+        notifications: [...prev.notifications, args.message],
+      }));
+      return "Notification displayed";
+    },
+  },
+};
+
+export default function App() {
+  const [state, setState] = useState({
+    theme: "light",
+    bgColor: "#ffffff",
+    notifications: [],
+    log: [],
+  });
+
+  const callTool = (name, args) => {
+    const result = tools[name].handler(args, setState);
+    setState(prev => ({
+      ...prev,
+      log: [...prev.log, \`Agent called \${name} → \${result}\`],
+    }));
+  };
+
+  const isDark = state.theme === "dark";
+
+  return (
+    <div style={{
+      fontFamily: "'Plus Jakarta Sans', sans-serif",
+      padding: 20,
+      background: isDark ? "#1a1a2e" : state.bgColor,
+      color: isDark ? "#e5e7eb" : "#374151",
+      minHeight: 300,
+      transition: "all 0.3s ease",
+    }}>
+      <h2 style={{ fontSize: 16, fontWeight: 700, marginBottom: 16 }}>
+        Frontend Tool Playground
+      </h2>
+
+      {/* Notifications */}
+      {state.notifications.map((msg, i) => (
+        <div key={i} style={{
+          padding: "8px 12px", marginBottom: 8, borderRadius: 8,
+          background: isDark ? "rgba(133, 224, 206, 0.2)" : "#ecfdf5",
+          border: \`1px solid \${isDark ? "rgba(133, 224, 206, 0.3)" : "#a7f3d0"}\`,
+          fontSize: 13,
+        }}>
+          {msg}
+        </div>
+      ))}
+
+      {/* Tool buttons (simulating agent tool calls) */}
+      <p style={{ fontSize: 12, color: isDark ? "#9ca3af" : "#6b7280", marginBottom: 8 }}>
+        Click buttons to simulate the agent calling frontend tools:
+      </p>
+      <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginBottom: 16 }}>
+        <ToolButton
+          label="Toggle Dark Mode"
+          onClick={() => callTool("toggleTheme", { theme: isDark ? "light" : "dark" })}
+          isDark={isDark}
+        />
+        <ToolButton
+          label="Pink Background"
+          onClick={() => callTool("setBackground", { color: "#fce7f3" })}
+          isDark={isDark}
+        />
+        <ToolButton
+          label="Blue Background"
+          onClick={() => callTool("setBackground", { color: "#dbeafe" })}
+          isDark={isDark}
+        />
+        <ToolButton
+          label="Notify: Hello!"
+          onClick={() => callTool("addNotification", { message: "Hello from the agent! 👋" })}
+          isDark={isDark}
+        />
+      </div>
+
+      {/* Tool call log */}
+      {state.log.length > 0 && (
+        <div style={{
+          padding: 12, borderRadius: 8, fontSize: 12,
+          background: isDark ? "rgba(255,255,255,0.05)" : "#f9fafb",
+          border: \`1px solid \${isDark ? "rgba(255,255,255,0.1)" : "#e5e7eb"}\`,
+          fontFamily: "monospace",
+        }}>
+          <div style={{ fontWeight: 600, marginBottom: 4, fontFamily: "'Plus Jakarta Sans', sans-serif" }}>
+            Tool Call Log:
+          </div>
+          {state.log.map((entry, i) => (
+            <div key={i} style={{ color: isDark ? "#9ca3af" : "#6b7280" }}>
+              {entry}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ToolButton({ label, onClick, isDark }) {
+  return (
+    <button
+      onClick={onClick}
+      style={{
+        padding: "6px 14px", borderRadius: 8, border: "none",
+        background: isDark ? "rgba(190, 194, 255, 0.2)" : "#9599CC",
+        color: isDark ? "#BEC2FF" : "#fff",
+        cursor: "pointer", fontWeight: 600, fontSize: 12,
+      }}
+    >
+      {label}
+    </button>
+  );
+}`,
+      },
+    },
+  ],
+};

--- a/apps/notebook/src/content/chapters/05-frontend-tools.ts
+++ b/apps/notebook/src/content/chapters/05-frontend-tools.ts
@@ -1,220 +1,329 @@
 import type { Chapter } from "@/lib/types";
 
-export const frontendTools: Chapter = {
-  id: "frontend-tools",
-  title: "Frontend Tools",
+export const mcpSkills: Chapter = {
+  id: "mcp-skills",
+  title: "MCP Skills",
   description:
-    "How the agent calls JavaScript functions in the browser.",
-  icon: "🛠",
+    "Composable skill documents that guide the agent's visual output quality.",
+  icon: "📜",
   cells: [
     {
       type: "markdown",
-      id: "tools-concept",
-      content: `# Frontend Tools
+      id: "skills-overview",
+      content: `# MCP Skills
 
-Frontend tools let the agent **execute JavaScript in the browser**. This is different from component tools (which render UI) — frontend tools perform actions like:
+The agent's visual quality comes from **skill documents** — composable \`.txt\` playbooks that define design rules, component patterns, and rendering techniques.
 
-- Toggling theme (light/dark mode)
-- Navigating to a page
-- Triggering animations
-- Reading browser state (viewport size, scroll position)
-- Modifying DOM elements
+Skills are served through an **MCP (Model Context Protocol) server**, making them accessible to both the LangGraph agent and external AI tools like Claude Desktop.
 
-The agent sees these tools in its tool list and can call them as needed during a conversation.`,
-    },
-    {
-      type: "code",
-      id: "tools-toggle-theme",
-      language: "tsx",
-      filename: "apps/app/src/hooks/use-generative-ui-examples.tsx — toggleTheme",
-      content: `import { useFrontendTool } from "@copilotkit/react-core";
-import { z } from "zod";
-import { useTheme } from "@/hooks/use-theme";
+## Skill Architecture
 
-// Inside the hook setup function:
-const { setTheme } = useTheme();
+\`\`\`
+apps/mcp/
+├── skills/
+│   ├── master-agent-playbook.txt    # Core philosophy, response patterns
+│   ├── svg-diagram-skill.txt        # SVG setup, typography, color ramps
+│   └── agent-skills-vol2.txt        # Advanced design system, UI mockups
+└── src/
+    ├── server.ts    # MCP server (resources, prompts, tools)
+    ├── skills.ts    # Skill file loader
+    └── renderer.ts  # HTML document assembly with design system
+\`\`\`
 
-useFrontendTool("toggleTheme", {
-  description: "Toggle between light and dark mode",
-  schema: z.object({
-    theme: z.enum(["light", "dark"]),
-  }),
-  handler: ({ theme }) => {
-    setTheme(theme);
-    return \`Theme switched to \${theme}\`;
-  },
-});`,
+The agent also has a local \`skills/\` directory loaded via \`create_deep_agent(skills=[...])\` — these are loaded at agent startup and available as contextual instructions.`,
     },
     {
       type: "markdown",
-      id: "tools-render",
-      content: `## Render Tools (useRenderTool)
+      id: "skills-mcp-server",
+      content: `## MCP Server
 
-Sometimes you want a tool that **both executes logic AND renders UI** while it runs. \`useRenderTool()\` shows a component during tool execution — perfect for progress indicators, previews, or step-by-step visualizations:`,
+The MCP server exposes skills in three ways:
+
+| MCP concept | Name | What it provides |
+|-------------|------|-----------------|
+| **Resource** | \`skills://list\` | JSON array of available skill names |
+| **Resource** | \`skills://{name}\` | Full text of a specific skill |
+| **Prompt** | \`create_widget\` | master-agent-playbook.txt as a pre-composed prompt |
+| **Prompt** | \`create_svg_diagram\` | svg-diagram-skill.txt |
+| **Prompt** | \`create_visualization\` | agent-skills-vol2.txt |
+| **Tool** | \`assemble_document\` | Wraps raw HTML with the full design system CSS/JS |`,
     },
     {
       type: "code",
-      id: "tools-render-code",
-      language: "tsx",
-      filename: "Plan visualization render tool",
-      content: `import { useRenderTool } from "@copilotkit/react-core";
-import { PlanCard } from "../components/generative-ui/plan-card";
+      id: "skills-server-code",
+      language: "typescript",
+      filename: "apps/mcp/src/server.ts",
+      content: `import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { listSkills, loadSkill } from "./skills.js";
+import { assembleDocument } from "./renderer.js";
 
-useRenderTool("plan_visualization", {
-  description: "Show planning progress to the user",
-  schema: z.object({
-    status: z.string(),
-    approach: z.string(),
-    technology: z.string(),
-    keyElements: z.array(z.string()),
-  }),
-  component: PlanCard,
-  // Tool can also return data to the agent
-  handler: (props) => \`Plan displayed: \${props.approach}\`,
-});`,
+export function createMcpServer(): McpServer {
+  const server = new McpServer({
+    name: "open-generative-ui",
+    version: "0.1.0",
+  });
+
+  // Resources: list and read skill documents
+  server.registerResource("skills-list", "skills://list", {
+    description: "JSON array of available skill names",
+    mimeType: "application/json",
+  }, async () => ({
+    contents: [{ uri: "skills://list", text: JSON.stringify(listSkills()) }],
+  }));
+
+  server.registerResource("skill",
+    new ResourceTemplate("skills://{name}", { /* ... */ }),
+    { description: "Full text of a skill document" },
+    async (uri, { name }) => ({
+      contents: [{ uri: uri.href, text: loadSkill(name as string) }],
+    })
+  );
+
+  // Prompts: pre-composed skill instructions
+  server.registerPrompt("create_widget", {
+    description: "Instructions for creating interactive HTML widgets",
+  }, async () => ({
+    messages: [{ role: "user", content: {
+      type: "text", text: loadSkill("master-agent-playbook")
+    }}],
+  }));
+
+  // Tool: wrap HTML with the full design system
+  server.registerTool("assemble_document", {
+    description: "Wraps HTML with theme CSS, SVG classes, form styles, and bridge JS",
+    inputSchema: {
+      title: z.string(),
+      description: z.string(),
+      html: z.string().describe("Self-contained HTML fragment"),
+    },
+  }, async ({ html }) => ({
+    content: [{ type: "text", text: assembleDocument(html) }],
+  }));
+
+  return server;
+}`,
+    },
+    {
+      type: "markdown",
+      id: "skills-playbook",
+      content: `## Master Agent Playbook
+
+The core skill document defines the agent's **response philosophy** and **decision tree**:
+
+**"Show, don't tell"** — the agent prioritizes visuals over text.
+
+### Response Decision Tree
+
+| User asks about... | Agent produces... |
+|---------------------|-------------------|
+| Quick fact | 1-2 sentences of text |
+| Concept / visual | SVG diagram |
+| Process / flow | Flowchart or stepper |
+| Data-driven question | Interactive chart |
+| Abstract / explorable | Interactive widget |
+| Working code | Running artifact |
+| Comparison | Side-by-side visual |
+
+### 3-Layer Response Pattern
+
+Every visual response uses:
+1. **Hook** (1-2 sentences) — Validate the question, set context
+2. **Visual** — The core explanation as a rendered component
+3. **Narration** (2-4 paragraphs) — Walk through the visual, offer to go deeper`,
+    },
+    {
+      type: "markdown",
+      id: "skills-svg",
+      content: `## SVG Diagram Skill
+
+Defines precise rules for hand-drawn SVG diagrams:
+
+- **ViewBox**: Always 680px wide, height = bottom element y + height + 40px
+- **Typography**: 14px titles, 12px subtitles, weights 400/500 only, sentence case
+- **Text width estimation**: 14px = 8px/char, 12px = 7px/char, +48px padding
+- **9 color ramps**: Teal, Purple, Coral, Pink, Gray, Blue, Green, Amber, Red — each with light/dark variants
+- **Node heights**: Single-line = 44px, two-line = 56px
+- **Arrows**: stroke-width 1.5px, marker-end, never cross boxes
+- **Critical checks**: ViewBox height correct, text fits rectangles, all paths have fill="none"`,
+    },
+    {
+      type: "markdown",
+      id: "skills-vol2",
+      content: `## Advanced Skills (Vol. 2)
+
+The advanced skill document adds a **full design system** with CSS variables:
+
+\`\`\`
+--color-background-primary/secondary/tertiary/info/danger/success/warning
+--color-text-primary/secondary/tertiary/info/danger/success/warning
+--color-border-primary/secondary/tertiary/info/danger/success/warning
+--font-sans/serif/mono
+--border-radius-md(8px)/lg(12px)/xl(16px)
+\`\`\`
+
+**Key rules**:
+- Typography: h1=22px, h2=18px, h3=16px, body=16px, all weight 500 max
+- Borders: 0.5px solid with tertiary border color
+- Cards: primary background, tertiary border, lg radius, 1rem padding
+- **Explicitly banned**: Gradients, shadows, blur, glow, neon, emoji
+- Min font-size: 11px`,
+    },
+    {
+      type: "code",
+      id: "skills-renderer",
+      language: "typescript",
+      filename: "apps/mcp/src/renderer.ts — assembleDocument (simplified)",
+      content: `// The assemble_document tool wraps agent HTML with:
+// 1. Theme CSS — light/dark mode variables
+// 2. SVG Classes — .c-purple, .c-teal, .c-blue, etc.
+// 3. Form Styles — native-looking buttons, inputs, sliders
+// 4. Bridge JS — sendPrompt(), openLink(), auto-resize
+
+export function assembleDocument(html: string): string {
+  return \`<!DOCTYPE html>
+<html>
+<head>
+  <style>\${THEME_CSS}</style>
+  <style>\${SVG_CLASSES_CSS}</style>
+  <style>\${FORM_STYLES_CSS}</style>
+</head>
+<body>
+  \${html}
+  <script>\${BRIDGE_JS}</script>
+</body>
+</html>\`;
+}
+
+// WARNING: Keep in sync with widget-renderer.tsx
+// when the design system changes.`,
     },
     {
       type: "playground",
-      id: "tools-playground",
-      title: "Try it: Frontend Tool Simulation",
+      id: "skills-playground",
+      title: "Try it: Skill-Guided SVG Diagram",
       files: {
         "/App.js": `import { useState } from "react";
 
-// Simulating frontend tools the agent can call
-const tools = {
-  toggleTheme: {
-    description: "Toggle between light and dark mode",
-    handler: (args, setState) => {
-      setState(prev => ({ ...prev, theme: args.theme }));
-      return \`Switched to \${args.theme} mode\`;
-    },
-  },
-  setBackground: {
-    description: "Change the background color",
-    handler: (args, setState) => {
-      setState(prev => ({ ...prev, bgColor: args.color }));
-      return \`Background set to \${args.color}\`;
-    },
-  },
-  addNotification: {
-    description: "Show a notification to the user",
-    handler: (args, setState) => {
-      setState(prev => ({
-        ...prev,
-        notifications: [...prev.notifications, args.message],
-      }));
-      return "Notification displayed";
-    },
-  },
+// This demonstrates the SVG diagram skill rules:
+// - ViewBox 680px wide, responsive
+// - 14px titles, 12px subtitles
+// - 9 color ramps with light/dark variants
+// - Proper text width estimation
+
+const colors = {
+  teal:   { fill: "#E1F5EE", stroke: "#0F6E56", text: "#085041" },
+  purple: { fill: "#EDE9F5", stroke: "#5B3FA0", text: "#3E2B6F" },
+  coral:  { fill: "#FCE8E8", stroke: "#C44D4D", text: "#8A2E2E" },
+  blue:   { fill: "#E3EFFC", stroke: "#2663B3", text: "#1A4680" },
+  amber:  { fill: "#FEF3DC", stroke: "#B8860B", text: "#7A5A07" },
 };
 
-export default function App() {
-  const [state, setState] = useState({
-    theme: "light",
-    bgColor: "#ffffff",
-    notifications: [],
-    log: [],
-  });
+function DiagramBuilder() {
+  const [nodes, setNodes] = useState([
+    { id: 1, label: "User Input", sub: "Chat message", color: "teal", x: 250, y: 40 },
+    { id: 2, label: "CopilotKit Runtime", sub: "API route", color: "purple", x: 250, y: 130 },
+    { id: 3, label: "LangGraph Agent", sub: "Tools + state", color: "blue", x: 250, y: 220 },
+    { id: 4, label: "Widget Renderer", sub: "Sandboxed iframe", color: "coral", x: 250, y: 310 },
+  ]);
 
-  const callTool = (name, args) => {
-    const result = tools[name].handler(args, setState);
-    setState(prev => ({
-      ...prev,
-      log: [...prev.log, \`Agent called \${name} → \${result}\`],
-    }));
+  const [selectedColor, setSelectedColor] = useState("teal");
+
+  const addNode = () => {
+    const lastY = nodes.length > 0 ? nodes[nodes.length - 1].y : -50;
+    setNodes([...nodes, {
+      id: Date.now(),
+      label: "New Node",
+      sub: "Description",
+      color: selectedColor,
+      x: 250,
+      y: lastY + 90,
+    }]);
   };
 
-  const isDark = state.theme === "dark";
+  const svgHeight = nodes.length > 0
+    ? nodes[nodes.length - 1].y + 56 + 40  // last y + node height + padding
+    : 100;
 
   return (
-    <div style={{
-      fontFamily: "'Plus Jakarta Sans', sans-serif",
-      padding: 20,
-      background: isDark ? "#1a1a2e" : state.bgColor,
-      color: isDark ? "#e5e7eb" : "#374151",
-      minHeight: 300,
-      transition: "all 0.3s ease",
-    }}>
-      <h2 style={{ fontSize: 16, fontWeight: 700, marginBottom: 16 }}>
-        Frontend Tool Playground
+    <div style={{ fontFamily: "system-ui, sans-serif", padding: 20 }}>
+      <h2 style={{ fontSize: 16, fontWeight: 700, marginBottom: 12 }}>
+        SVG Diagram Skill Rules
       </h2>
 
-      {/* Notifications */}
-      {state.notifications.map((msg, i) => (
-        <div key={i} style={{
-          padding: "8px 12px", marginBottom: 8, borderRadius: 8,
-          background: isDark ? "rgba(133, 224, 206, 0.2)" : "#ecfdf5",
-          border: \`1px solid \${isDark ? "rgba(133, 224, 206, 0.3)" : "#a7f3d0"}\`,
-          fontSize: 13,
-        }}>
-          {msg}
-        </div>
-      ))}
+      <svg width="100%" viewBox={\`0 0 680 \${svgHeight}\`} xmlns="http://www.w3.org/2000/svg">
+        {/* Arrow marker */}
+        <defs>
+          <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5"
+            markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+            <path d="M2 1L8 5L2 9" fill="none" stroke="context-stroke"
+              strokeWidth="1.5" strokeLinecap="round" />
+          </marker>
+        </defs>
 
-      {/* Tool buttons (simulating agent tool calls) */}
-      <p style={{ fontSize: 12, color: isDark ? "#9ca3af" : "#6b7280", marginBottom: 8 }}>
-        Click buttons to simulate the agent calling frontend tools:
-      </p>
-      <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginBottom: 16 }}>
-        <ToolButton
-          label="Toggle Dark Mode"
-          onClick={() => callTool("toggleTheme", { theme: isDark ? "light" : "dark" })}
-          isDark={isDark}
-        />
-        <ToolButton
-          label="Pink Background"
-          onClick={() => callTool("setBackground", { color: "#fce7f3" })}
-          isDark={isDark}
-        />
-        <ToolButton
-          label="Blue Background"
-          onClick={() => callTool("setBackground", { color: "#dbeafe" })}
-          isDark={isDark}
-        />
-        <ToolButton
-          label="Notify: Hello!"
-          onClick={() => callTool("addNotification", { message: "Hello from the agent! 👋" })}
-          isDark={isDark}
-        />
+        {/* Connectors */}
+        {nodes.slice(1).map((node, i) => {
+          const prev = nodes[i];
+          return (
+            <line key={\`arrow-\${i}\`}
+              x1={prev.x + 90} y1={prev.y + 56}
+              x2={node.x + 90} y2={node.y}
+              stroke="#9ca3af" strokeWidth="1.5"
+              markerEnd="url(#arrow)"
+            />
+          );
+        })}
+
+        {/* Nodes */}
+        {nodes.map(node => {
+          const c = colors[node.color];
+          // Text width: 14px = 8px/char, 12px = 7px/char, +48px padding
+          const titleW = node.label.length * 8;
+          const subW = node.sub.length * 7;
+          const w = Math.max(titleW, subW) + 48;
+          return (
+            <g key={node.id}>
+              <rect x={node.x} y={node.y} width={w} height={56}
+                rx="8" fill={c.fill} stroke={c.stroke} strokeWidth="1" />
+              <text x={node.x + w/2} y={node.y + 22}
+                textAnchor="middle" dominantBaseline="central"
+                style={{ fontSize: 14, fontWeight: 500, fill: c.text }}>
+                {node.label}
+              </text>
+              <text x={node.x + w/2} y={node.y + 40}
+                textAnchor="middle" dominantBaseline="central"
+                style={{ fontSize: 12, fill: c.text, opacity: 0.7 }}>
+                {node.sub}
+              </text>
+            </g>
+          );
+        })}
+      </svg>
+
+      <div style={{ display: "flex", gap: 8, marginTop: 12, alignItems: "center" }}>
+        {Object.keys(colors).map(c => (
+          <button key={c} onClick={() => setSelectedColor(c)} style={{
+            width: 28, height: 28, borderRadius: 6,
+            background: colors[c].fill, border: \`2px solid \${selectedColor === c ? colors[c].stroke : "transparent"}\`,
+            cursor: "pointer",
+          }} title={c} />
+        ))}
+        <button onClick={addNode} style={{
+          padding: "6px 14px", borderRadius: 8, border: "none",
+          background: "#9599CC", color: "#fff", cursor: "pointer",
+          fontWeight: 600, fontSize: 12,
+        }}>
+          + Add Node
+        </button>
       </div>
 
-      {/* Tool call log */}
-      {state.log.length > 0 && (
-        <div style={{
-          padding: 12, borderRadius: 8, fontSize: 12,
-          background: isDark ? "rgba(255,255,255,0.05)" : "#f9fafb",
-          border: \`1px solid \${isDark ? "rgba(255,255,255,0.1)" : "#e5e7eb"}\`,
-          fontFamily: "monospace",
-        }}>
-          <div style={{ fontWeight: 600, marginBottom: 4, fontFamily: "'Plus Jakarta Sans', sans-serif" }}>
-            Tool Call Log:
-          </div>
-          {state.log.map((entry, i) => (
-            <div key={i} style={{ color: isDark ? "#9ca3af" : "#6b7280" }}>
-              {entry}
-            </div>
-          ))}
-        </div>
-      )}
+      <p style={{ fontSize: 11, color: "#9ca3af", marginTop: 8 }}>
+        ViewBox: 680 x {svgHeight} | Nodes: 56px tall | Text: 14px/12px | Width = max(chars x 8, chars x 7) + 48
+      </p>
     </div>
   );
 }
 
-function ToolButton({ label, onClick, isDark }) {
-  return (
-    <button
-      onClick={onClick}
-      style={{
-        padding: "6px 14px", borderRadius: 8, border: "none",
-        background: isDark ? "rgba(190, 194, 255, 0.2)" : "#9599CC",
-        color: isDark ? "#BEC2FF" : "#fff",
-        cursor: "pointer", fontWeight: 600, fontSize: 12,
-      }}
-    >
-      {label}
-    </button>
-  );
-}`,
+export default DiagramBuilder;`,
       },
     },
   ],

--- a/apps/notebook/src/content/chapters/05-frontend-tools.ts
+++ b/apps/notebook/src/content/chapters/05-frontend-tools.ts
@@ -77,27 +77,41 @@ The principle: **Show, don't just tell.** Before writing any response:
       id: "skills-decision-tree",
       content: `## The Response Decision Tree
 
-The master playbook teaches the agent to choose the right output format based on what the user is asking:
+The master playbook teaches the agent to choose the right output format based on what the user is asking:`,
+    },
+    {
+      type: "mermaid",
+      id: "skills-decision-diagram",
+      title: "Skill Decision Tree",
+      content: `flowchart TD
+    Q[User asks a question] --> F{Question type?}
+    F -->|Quick factual| T[1-2 sentences of text]
+    F -->|Conceptual| C{Sub-type?}
+    F -->|Build me X| A[Working code artifact]
+    F -->|Comparison| S[Side-by-side visual]
+    F -->|Emotional| W[Warm text only]
 
-\`\`\`
-User asks a question
-  |
-  +-- Quick factual answer?  →  1-2 sentences of text
-  |
-  +-- Conceptual / "how does X work"?
-  |     +-- Spatial or visual?       →  SVG diagram
-  |     +-- Process or flow?         →  Flowchart or HTML stepper
-  |     +-- Data-driven?             →  Interactive chart
-  |     +-- Abstract but explorable? →  Interactive widget with controls
-  |
-  +-- "Build me X"?  →  Working code artifact
-  |
-  +-- Comparison?    →  Side-by-side visual
-  |
-  +-- Emotional?     →  Warm text only, no visuals
-\`\`\`
+    C -->|Spatial / visual| SVG[SVG diagram]
+    C -->|Process / flow| FL[Flowchart or stepper]
+    C -->|Data-driven| CH[Interactive chart]
+    C -->|Abstract| WI[Widget with controls]
 
-The playground below shows this in action — pick different question types and see the skill guide the agent to produce different output formats:`,
+    style Q fill:#EDE9F5,stroke:#5B3FA0,color:#3E2B6F
+    style F fill:#FAEEDA,stroke:#B8860B,color:#854F0B
+    style C fill:#FAEEDA,stroke:#B8860B,color:#854F0B
+    style T fill:#f7f6f3,stroke:#9c9a92,color:#1a1a1a
+    style A fill:#E1F5EE,stroke:#0F6E56,color:#085041
+    style S fill:#E3EFFC,stroke:#2663B3,color:#1A4680
+    style W fill:#f7f6f3,stroke:#9c9a92,color:#1a1a1a
+    style SVG fill:#E1F5EE,stroke:#0F6E56,color:#085041
+    style FL fill:#E1F5EE,stroke:#0F6E56,color:#085041
+    style CH fill:#E3EFFC,stroke:#2663B3,color:#1A4680
+    style WI fill:#E3EFFC,stroke:#2663B3,color:#1A4680`,
+    },
+    {
+      type: "markdown",
+      id: "skills-decision-tree-cta",
+      content: `The playground below shows this in action — pick different question types and see the skill guide the agent to produce different output formats:`,
     },
     {
       type: "playground",

--- a/apps/notebook/src/content/chapters/05-frontend-tools.ts
+++ b/apps/notebook/src/content/chapters/05-frontend-tools.ts
@@ -1,61 +1,268 @@
 import type { Chapter } from "@/lib/types";
 
-export const mcpSkills: Chapter = {
-  id: "mcp-skills",
-  title: "MCP Skills",
+export const agentSkills: Chapter = {
+  id: "agent-skills",
+  title: "Agent Skills",
   description:
-    "Composable skill documents that guide the agent's visual output quality.",
+    "How skill documents teach the agent to write high-quality visual code.",
   icon: "📜",
   cells: [
     {
       type: "markdown",
       id: "skills-overview",
-      content: `# MCP Skills
+      content: `# Agent Skills
 
-The agent's visual quality comes from **skill documents** — composable \`.txt\` playbooks that define design rules, component patterns, and rendering techniques.
+The agent doesn't just have tools — it has **skills**. Skills are markdown documents loaded at startup via \`create_deep_agent(skills=[...])\` that teach the agent *how* to write HTML, SVG, and interactive code.
 
-Skills are served through an **MCP (Model Context Protocol) server**, making them accessible to both the LangGraph agent and external AI tools like Claude Desktop.`,
+Without skills, the agent produces generic output. With skills, it follows a consistent design system, uses proper typography, picks from a curated color palette, and structures responses with the 3-layer pattern (hook → visual → narration).
+
+## Three Skill Documents
+
+| Skill | What it teaches |
+|-------|----------------|
+| **Master Playbook** | Response philosophy, decision tree, interactive widget templates, Chart.js patterns |
+| **SVG Diagrams** | Precise SVG rules: 680px viewBox, 9 color ramps, text sizing, arrow markers |
+| **Advanced Visualization** | Design system tokens, UI mockup patterns, dashboard layouts, dark mode |`,
     },
     {
       type: "code",
-      id: "skills-server-code",
-      language: "typescript",
-      filename: "apps/mcp/src/server.ts (simplified)",
-      content: `export function createMcpServer(): McpServer {
-  const server = new McpServer({ name: "open-generative-ui", version: "0.1.0" });
+      id: "skills-loading",
+      language: "python",
+      filename: "apps/agent/main.py — skills loaded at startup",
+      content: `agent = create_deep_agent(
+    model=ChatOpenAI(model="gpt-5.4-2026-03-05"),
+    tools=[query_data, plan_visualization, *todo_tools, generate_form],
+    middleware=[CopilotKitMiddleware()],
+    context_schema=AgentState,
+    # Skills are loaded from this directory at startup
+    # Each subfolder contains a SKILL.md with frontmatter
+    skills=[str(Path(__file__).parent / "skills")],
+    checkpointer=BoundedMemorySaver(max_threads=200),
+    system_prompt="...",
+)
 
-  // Resources: list and read skill documents
-  server.registerResource("skills-list", "skills://list", { ... });
-  server.registerResource("skill", new ResourceTemplate("skills://{name}"), { ... });
+# apps/agent/skills/
+# ├── master-playbook/SKILL.md      → Response philosophy + widget templates
+# ├── svg-diagrams/SKILL.md         → SVG generation rules
+# └── advanced-visualization/SKILL.md → Design system + advanced patterns`,
+    },
+    {
+      type: "code",
+      id: "skills-frontmatter",
+      language: "markdown",
+      filename: "apps/agent/skills/master-playbook/SKILL.md (excerpt)",
+      content: `---
+name: "Master Agent Playbook"
+description: "Philosophy, decision-making framework, and technical skills
+  for delivering visual, interactive, and educational AI responses."
+allowed-tools: []
+---
 
-  // Prompts: pre-composed skill instructions
-  server.registerPrompt("create_widget", { ... });       // master-agent-playbook
-  server.registerPrompt("create_svg_diagram", { ... });   // svg-diagram-skill
-  server.registerPrompt("create_visualization", { ... }); // agent-skills-vol2
+# Master Agent Playbook: Making AI Responses Extraordinary
 
-  // Tool: wrap HTML with the full design system
-  server.registerTool("assemble_document", {
-    inputSchema: { title, description, html },
-  }, async ({ html }) => ({
-    content: [{ type: "text", text: assembleDocument(html) }],
-  }));
+## The Core Philosophy
+
+### Think Like a Teacher, Not a Search Engine
+
+Bad: "A load path is the route that forces take through a structure."
+Good: [draws an interactive building cross-section with loads flowing]
+
+The principle: **Show, don't just tell.** Before writing any response:
+- Would a diagram make this click faster than a paragraph?
+- Would an interactive widget let the user explore themselves?
+- Would a worked example teach better than a definition?`,
+    },
+    {
+      type: "markdown",
+      id: "skills-decision-tree",
+      content: `## The Response Decision Tree
+
+The master playbook teaches the agent to choose the right output format based on what the user is asking:
+
+\`\`\`
+User asks a question
+  |
+  +-- Quick factual answer?  →  1-2 sentences of text
+  |
+  +-- Conceptual / "how does X work"?
+  |     +-- Spatial or visual?       →  SVG diagram
+  |     +-- Process or flow?         →  Flowchart or HTML stepper
+  |     +-- Data-driven?             →  Interactive chart
+  |     +-- Abstract but explorable? →  Interactive widget with controls
+  |
+  +-- "Build me X"?  →  Working code artifact
+  |
+  +-- Comparison?    →  Side-by-side visual
+  |
+  +-- Emotional?     →  Warm text only, no visuals
+\`\`\`
+
+The playground below shows this in action — pick different question types and see the skill guide the agent to produce different output formats:`,
+    },
+    {
+      type: "playground",
+      id: "skills-decision-playground",
+      title: "Live: Skill-guided response format selection",
+      files: {
+        "/App.js": `import { useState, useRef, useEffect } from "react";
+
+// The skill decision tree in action: different questions → different output formats
+
+const questions = [
+  {
+    text: "How does a load balancer distribute traffic?",
+    type: "Process / flow",
+    format: "SVG flowchart",
+    output: \`<svg width="100%" viewBox="0 0 680 310" xmlns="http://www.w3.org/2000/svg" style="display:block">
+      <defs><marker id="a" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto"><path d="M2 1L8 5L2 9" fill="none" stroke="context-stroke" stroke-width="1.5" stroke-linecap="round"/></marker></defs>
+      <rect x="255" y="20" width="170" height="44" rx="8" fill="#E3EFFC" stroke="#2663B3"/>
+      <text x="340" y="42" text-anchor="middle" dominant-baseline="central" style="font:500 14px system-ui;fill:#1A4680">Incoming request</text>
+      <line x1="340" y1="64" x2="340" y2="100" stroke="#9c9a92" stroke-width="1.5" marker-end="url(#a)"/>
+      <rect x="240" y="102" width="200" height="52" rx="8" fill="#EDE9F5" stroke="#5B3FA0"/>
+      <text x="340" y="122" text-anchor="middle" dominant-baseline="central" style="font:500 14px system-ui;fill:#3E2B6F">Load balancer</text>
+      <text x="340" y="140" text-anchor="middle" dominant-baseline="central" style="font:400 12px system-ui;fill:#3E2B6F;opacity:.7">Round-robin algorithm</text>
+      <line x1="280" y1="154" x2="140" y2="200" stroke="#9c9a92" stroke-width="1.5" marker-end="url(#a)"/>
+      <line x1="340" y1="154" x2="340" y2="200" stroke="#9c9a92" stroke-width="1.5" marker-end="url(#a)"/>
+      <line x1="400" y1="154" x2="540" y2="200" stroke="#9c9a92" stroke-width="1.5" marker-end="url(#a)"/>
+      <rect x="70" y="202" width="140" height="52" rx="8" fill="#E1F5EE" stroke="#0F6E56"/>
+      <text x="140" y="222" text-anchor="middle" dominant-baseline="central" style="font:500 14px system-ui;fill:#085041">Server A</text>
+      <text x="140" y="240" text-anchor="middle" dominant-baseline="central" style="font:400 12px system-ui;fill:#085041;opacity:.7">cpu: 45%</text>
+      <rect x="270" y="202" width="140" height="52" rx="8" fill="#E1F5EE" stroke="#0F6E56"/>
+      <text x="340" y="222" text-anchor="middle" dominant-baseline="central" style="font:500 14px system-ui;fill:#085041">Server B</text>
+      <text x="340" y="240" text-anchor="middle" dominant-baseline="central" style="font:400 12px system-ui;fill:#085041;opacity:.7">cpu: 62%</text>
+      <rect x="470" y="202" width="140" height="52" rx="8" fill="#E1F5EE" stroke="#0F6E56"/>
+      <text x="540" y="222" text-anchor="middle" dominant-baseline="central" style="font:500 14px system-ui;fill:#085041">Server C</text>
+      <text x="540" y="240" text-anchor="middle" dominant-baseline="central" style="font:400 12px system-ui;fill:#085041;opacity:.7">cpu: 28%</text>
+    </svg>\`,
+  },
+  {
+    text: "Compare React vs Vue vs Svelte bundle sizes",
+    type: "Data-driven comparison",
+    format: "Interactive chart",
+    output: \`<style>
+      body{font-family:system-ui,sans-serif;padding:16px;margin:0}
+      .row{display:flex;align-items:center;gap:10px;margin:8px 0}
+      .lbl{width:70px;font-size:13px;color:#73726c;text-align:right}
+      .track{flex:1;height:28px;background:#f7f6f3;border-radius:6px;overflow:hidden;position:relative}
+      .fill{height:100%;border-radius:6px;display:flex;align-items:center;padding-left:10px;
+        font-size:12px;color:#fff;font-weight:500;animation:grow .8s ease forwards;transform-origin:left}
+      .val{width:50px;font-size:12px;color:#73726c}
+      h3{font-size:16px;font-weight:500;margin:0 0 12px;color:#1a1a1a}
+      @keyframes grow{from{transform:scaleX(0)}to{transform:scaleX(1)}}
+    </style>
+    <h3>Framework bundle size (production, gzipped)</h3>
+    <div class="row"><span class="lbl">React</span><div class="track"><div class="fill" style="width:72%;background:#5B3FA0">42.2 KB</div></div></div>
+    <div class="row"><span class="lbl">Vue</span><div class="track"><div class="fill" style="width:55%;background:#0F6E56;animation-delay:.15s">33.0 KB</div></div></div>
+    <div class="row"><span class="lbl">Svelte</span><div class="track"><div class="fill" style="width:12%;background:#C44D4D;animation-delay:.3s">1.6 KB</div></div></div>
+    <p style="font-size:12px;color:#9c9a92;margin-top:12px">Svelte compiles away the framework — the output is vanilla JS with no runtime.</p>\`,
+  },
+  {
+    text: "Build me a Pomodoro timer",
+    type: "Build request",
+    format: "Working interactive widget",
+    output: \`<style>
+      body{font-family:system-ui,sans-serif;padding:20px;margin:0;text-align:center}
+      .timer{font-size:48px;font-weight:500;color:#1a1a1a;margin:16px 0 8px;font-variant-numeric:tabular-nums}
+      .label{font-size:13px;color:#73726c;margin-bottom:16px}
+      .btn{padding:10px 24px;border-radius:8px;border:none;font-size:14px;font-weight:500;cursor:pointer;margin:0 4px}
+      .start{background:#0F6E56;color:#fff} .pause{background:#B8860B;color:#fff}
+      .reset{background:#f7f6f3;color:#73726c;border:0.5px solid rgba(0,0,0,.15)}
+      .progress{width:200px;height:6px;background:#f7f6f3;border-radius:3px;margin:0 auto 16px;overflow:hidden}
+      .bar{height:100%;background:#0F6E56;border-radius:3px;transition:width .5s linear}
+    </style>
+    <h3 style="font-size:18px;font-weight:500;margin:0">Pomodoro Timer</h3>
+    <div class="timer" id="display">25:00</div>
+    <div class="label" id="mode">Focus time</div>
+    <div class="progress"><div class="bar" id="bar" style="width:100%"></div></div>
+    <button class="btn start" id="startBtn" onclick="toggle()">Start</button>
+    <button class="btn reset" onclick="reset()">Reset</button>
+    <script>
+      let total=1500,remaining=1500,running=false,interval=null;
+      const d=document.getElementById('display'),b=document.getElementById('bar'),s=document.getElementById('startBtn');
+      function fmt(s){return Math.floor(s/60).toString().padStart(2,'0')+':'+String(s%60).padStart(2,'0')}
+      function toggle(){
+        running=!running;s.textContent=running?'Pause':'Start';
+        s.className='btn '+(running?'pause':'start');
+        if(running)interval=setInterval(()=>{if(remaining>0){remaining--;d.textContent=fmt(remaining);b.style.width=(remaining/total*100)+'%'}else{clearInterval(interval);running=false;s.textContent='Start';s.className='btn start'}},1000);
+        else clearInterval(interval);
+      }
+      function reset(){clearInterval(interval);running=false;remaining=total;d.textContent=fmt(remaining);b.style.width='100%';s.textContent='Start';s.className='btn start'}
+    </script>\`,
+  },
+];
+
+export default function App() {
+  const [selected, setSelected] = useState(null);
+  const iframeRef = useRef(null);
+
+  useEffect(() => {
+    if (!iframeRef.current || selected === null) return;
+    const doc = iframeRef.current.contentDocument;
+    if (!doc) return;
+    doc.open();
+    doc.write(\`<!DOCTYPE html><html><body style="margin:0">\${questions[selected].output}</body></html>\`);
+    doc.close();
+  }, [selected]);
+
+  return (
+    <div style={{ fontFamily: "system-ui, sans-serif" }}>
+      {/* Question selector */}
+      <div style={{ padding: 16 }}>
+        <div style={{ fontSize: 13, fontWeight: 600, color: "#6b7280", marginBottom: 8 }}>
+          Pick a question — the skill guides the agent to the right output format:
+        </div>
+        <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+          {questions.map((q, i) => (
+            <button key={i} onClick={() => setSelected(i)} style={{
+              padding: "10px 14px", borderRadius: 10, border: selected === i ? "2px solid #5B3FA0" : "1px solid #e5e7eb",
+              background: selected === i ? "#f5f3ff" : "#fff", cursor: "pointer", textAlign: "left",
+              display: "flex", justifyContent: "space-between", alignItems: "center",
+            }}>
+              <span style={{ fontSize: 13, color: "#374151" }}>{q.text}</span>
+              <span style={{ fontSize: 10, padding: "2px 8px", borderRadius: 4,
+                background: selected === i ? "#EDE9F5" : "#f0f0f0",
+                color: selected === i ? "#5B3FA0" : "#9ca3af", fontWeight: 600, whiteSpace: "nowrap" }}>
+                {q.type} → {q.format}
+              </span>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Rendered output */}
+      {selected !== null && (
+        <div style={{ borderTop: "1px solid #e5e7eb" }}>
+          <div style={{ padding: "6px 16px", fontSize: 11, fontWeight: 600, color: "#5B3FA0",
+            background: "#f9fafb", borderBottom: "1px solid #e5e7eb", display: "flex", justifyContent: "space-between" }}>
+            <span>Agent output ({questions[selected].format})</span>
+            <span style={{ color: "#9ca3af", fontWeight: 400 }}>Rendered in sandboxed iframe</span>
+          </div>
+          <iframe ref={iframeRef} sandbox="allow-scripts"
+            style={{ width: "100%", height: selected === 2 ? 240 : 300, border: "none", display: "block" }} />
+        </div>
+      )}
+    </div>
+  );
 }`,
+      },
     },
     {
       type: "markdown",
       id: "skills-design-system",
       content: `## Design System Tokens
 
-The skill documents define a full token set that gets injected into every widget iframe. The playground below is a **live token explorer** — it renders real HTML using the same CSS variables the agent uses:`,
+The advanced visualization skill defines CSS variables that get injected into every widget. This means the agent writes code like \`color: var(--color-text-primary)\` instead of hardcoded hex values — and dark mode works automatically.
+
+The playground below renders actual HTML using these tokens, exactly as the widget renderer does:`,
     },
     {
       type: "playground",
       id: "skills-tokens-playground",
-      title: "Live: Design system token explorer with real rendering",
+      title: "Live: Design system tokens in action",
       files: {
         "/App.js": `import { useState, useRef, useEffect } from "react";
 
-// These are the actual CSS variables from renderer.ts
+// The REAL CSS variables from the skill document
 const THEME_CSS = \`
 :root {
   --color-background-primary: #ffffff;
@@ -74,7 +281,6 @@ const THEME_CSS = \`
   --color-text-warning: #854F0B;
   --color-border-tertiary: rgba(0, 0, 0, 0.15);
   --font-sans: system-ui, -apple-system, sans-serif;
-  --border-radius-md: 8px;
   --border-radius-lg: 12px;
 }
 @media (prefers-color-scheme: dark) {
@@ -90,54 +296,39 @@ body { font-family: var(--font-sans); margin: 0; padding: 16px;
   background: var(--color-background-primary); color: var(--color-text-primary); }
 \`;
 
-// Templates the user can switch between
 const templates = {
   "Status cards": \`<div style="display:grid;grid-template-columns:repeat(3,1fr);gap:12px">
   <div style="padding:14px;border-radius:var(--border-radius-lg);background:var(--color-background-success);border:0.5px solid var(--color-border-tertiary)">
     <div style="font-size:11px;color:var(--color-text-success)">Healthy</div>
-    <div style="font-size:22px;font-weight:500;color:var(--color-text-success)">12 services</div>
+    <div style="font-size:22px;font-weight:500;color:var(--color-text-success)">12</div>
   </div>
   <div style="padding:14px;border-radius:var(--border-radius-lg);background:var(--color-background-warning);border:0.5px solid var(--color-border-tertiary)">
     <div style="font-size:11px;color:var(--color-text-warning)">Degraded</div>
-    <div style="font-size:22px;font-weight:500;color:var(--color-text-warning)">2 services</div>
+    <div style="font-size:22px;font-weight:500;color:var(--color-text-warning)">2</div>
   </div>
   <div style="padding:14px;border-radius:var(--border-radius-lg);background:var(--color-background-danger);border:0.5px solid var(--color-border-tertiary)">
     <div style="font-size:11px;color:var(--color-text-danger)">Down</div>
-    <div style="font-size:22px;font-weight:500;color:var(--color-text-danger)">0 services</div>
-  </div>
-</div>\`,
-  "Info panel": \`<div style="padding:16px;border-radius:var(--border-radius-lg);background:var(--color-background-info);border:0.5px solid var(--color-border-tertiary)">
-  <div style="font-size:14px;font-weight:500;color:var(--color-text-info);margin-bottom:6px">How the design system works</div>
-  <div style="font-size:13px;color:var(--color-text-info);line-height:1.6">
-    Every widget gets these CSS variables injected automatically. Use <code style="background:rgba(0,0,0,0.06);padding:1px 4px;border-radius:3px">var(--color-text-primary)</code> instead of hardcoded colors and your widgets will support dark mode for free.
+    <div style="font-size:22px;font-weight:500;color:var(--color-text-danger)">0</div>
   </div>
 </div>\`,
   "Data table": \`<table style="width:100%;border-collapse:collapse;font-size:13px">
-  <thead>
-    <tr style="border-bottom:0.5px solid var(--color-border-tertiary)">
-      <th style="text-align:left;padding:8px;color:var(--color-text-tertiary);font-weight:500">Tool</th>
-      <th style="text-align:right;padding:8px;color:var(--color-text-tertiary);font-weight:500">Calls</th>
-      <th style="text-align:right;padding:8px;color:var(--color-text-tertiary);font-weight:500">Avg ms</th>
-    </tr>
-  </thead>
+  <thead><tr style="border-bottom:0.5px solid var(--color-border-tertiary)">
+    <th style="text-align:left;padding:8px;color:var(--color-text-tertiary);font-weight:500">Tool</th>
+    <th style="text-align:right;padding:8px;color:var(--color-text-tertiary);font-weight:500">Calls</th>
+    <th style="text-align:right;padding:8px;color:var(--color-text-tertiary);font-weight:500">Avg ms</th>
+  </tr></thead>
   <tbody>
-    <tr style="border-bottom:0.5px solid var(--color-border-tertiary)">
-      <td style="padding:8px;color:var(--color-text-primary)">widgetRenderer</td>
-      <td style="text-align:right;padding:8px;color:var(--color-text-primary);font-weight:500">847</td>
-      <td style="text-align:right;padding:8px;color:var(--color-text-success)">280</td>
-    </tr>
-    <tr style="border-bottom:0.5px solid var(--color-border-tertiary)">
-      <td style="padding:8px;color:var(--color-text-primary)">manage_todos</td>
-      <td style="text-align:right;padding:8px;color:var(--color-text-primary);font-weight:500">312</td>
-      <td style="text-align:right;padding:8px;color:var(--color-text-success)">45</td>
-    </tr>
-    <tr>
-      <td style="padding:8px;color:var(--color-text-primary)">plan_visualization</td>
-      <td style="text-align:right;padding:8px;color:var(--color-text-primary);font-weight:500">823</td>
-      <td style="text-align:right;padding:8px;color:var(--color-text-warning)">520</td>
-    </tr>
+    <tr style="border-bottom:0.5px solid var(--color-border-tertiary)"><td style="padding:8px">widgetRenderer</td><td style="text-align:right;padding:8px;font-weight:500">847</td><td style="text-align:right;padding:8px;color:var(--color-text-success)">280</td></tr>
+    <tr style="border-bottom:0.5px solid var(--color-border-tertiary)"><td style="padding:8px">manage_todos</td><td style="text-align:right;padding:8px;font-weight:500">312</td><td style="text-align:right;padding:8px;color:var(--color-text-success)">45</td></tr>
+    <tr><td style="padding:8px">plan_visualization</td><td style="text-align:right;padding:8px;font-weight:500">823</td><td style="text-align:right;padding:8px;color:var(--color-text-warning)">520</td></tr>
   </tbody>
 </table>\`,
+  "Info panel": \`<div style="padding:16px;border-radius:var(--border-radius-lg);background:var(--color-background-info);border:0.5px solid var(--color-border-tertiary)">
+  <div style="font-size:14px;font-weight:500;color:var(--color-text-info);margin-bottom:6px">How skills guide code generation</div>
+  <div style="font-size:13px;color:var(--color-text-info);line-height:1.6">
+    The agent writes <code style="background:rgba(0,0,0,.06);padding:1px 4px;border-radius:3px">var(--color-text-primary)</code> instead of hardcoded colors. This means every widget automatically supports dark mode — no extra code needed.
+  </div>
+</div>\`,
 };
 
 export default function App() {
@@ -147,7 +338,6 @@ export default function App() {
   useEffect(() => {
     if (!iframeRef.current) return;
     const doc = iframeRef.current.contentDocument;
-    if (!doc) return;
     doc.open();
     doc.write(\`<!DOCTYPE html><html><head><style>\${THEME_CSS}</style></head><body>\${templates[selected]}</body></html>\`);
     doc.close();
@@ -155,200 +345,26 @@ export default function App() {
 
   return (
     <div style={{ fontFamily: "system-ui, sans-serif" }}>
-      {/* Template selector */}
       <div style={{ padding: "10px 16px", borderBottom: "1px solid #e5e7eb", display: "flex", gap: 6 }}>
         {Object.keys(templates).map(name => (
           <button key={name} onClick={() => setSelected(name)} style={{
             padding: "5px 12px", borderRadius: 6, border: "none", fontSize: 12, fontWeight: 600, cursor: "pointer",
             background: selected === name ? "#5B3FA0" : "#f0f0f0",
             color: selected === name ? "#fff" : "#6b7280",
-          }}>
-            {name}
-          </button>
+          }}>{name}</button>
         ))}
       </div>
-
-      {/* Live rendered preview using the REAL design system CSS */}
-      <iframe
-        ref={iframeRef}
-        sandbox="allow-scripts"
-        style={{ width: "100%", height: 160, border: "none", display: "block" }}
-      />
-
-      {/* Show the HTML source */}
+      <iframe ref={iframeRef} sandbox="allow-scripts"
+        style={{ width: "100%", height: 130, border: "none", display: "block" }} />
       <div style={{ borderTop: "1px solid #e5e7eb", padding: 12, background: "#f9fafb" }}>
-        <div style={{ fontSize: 10, fontWeight: 600, color: "#6b7280", textTransform: "uppercase", marginBottom: 4 }}>HTML using design system tokens:</div>
-        <pre style={{ margin: 0, fontSize: 11, fontFamily: "monospace", color: "#374151", whiteSpace: "pre-wrap", maxHeight: 120, overflow: "auto", lineHeight: 1.5 }}>
+        <div style={{ fontSize: 10, fontWeight: 600, color: "#6b7280", textTransform: "uppercase", marginBottom: 4 }}>
+          HTML using design tokens (not hardcoded colors):
+        </div>
+        <pre style={{ margin: 0, fontSize: 11, fontFamily: "monospace", color: "#374151",
+          whiteSpace: "pre-wrap", maxHeight: 100, overflow: "auto", lineHeight: 1.5 }}>
           {templates[selected].trim()}
         </pre>
       </div>
-    </div>
-  );
-}`,
-      },
-    },
-    {
-      type: "markdown",
-      id: "skills-svg-rules",
-      content: `## SVG Diagram Skill
-
-The SVG skill defines precise rules for hand-drawn diagrams. The playground below implements these rules as a live diagram builder — add nodes, pick colors from the 9-ramp palette, and watch the SVG follow the viewBox/spacing rules:`,
-    },
-    {
-      type: "playground",
-      id: "skills-svg-playground",
-      title: "Live: SVG diagram builder following skill rules",
-      files: {
-        "/App.js": `import { useState } from "react";
-
-// Implements the actual SVG diagram skill rules:
-// - ViewBox 680px wide, responsive via width="100%"
-// - 14px titles (8px/char), 12px subtitles (7px/char), +48px padding
-// - Two-line nodes: 56px tall, single-line: 44px tall
-// - Arrow markers, stroke-width 1.5px
-// - 9 color ramps from the skill document
-
-const ramps = {
-  teal:   { fill: "#E1F5EE", stroke: "#0F6E56", text: "#085041" },
-  purple: { fill: "#EDE9F5", stroke: "#5B3FA0", text: "#3E2B6F" },
-  coral:  { fill: "#FCE8E8", stroke: "#C44D4D", text: "#8A2E2E" },
-  pink:   { fill: "#FAEAF3", stroke: "#B54A8C", text: "#7E3362" },
-  gray:   { fill: "#F1F1F0", stroke: "#73726C", text: "#474745" },
-  blue:   { fill: "#E3EFFC", stroke: "#2663B3", text: "#1A4680" },
-  green:  { fill: "#E1F5EE", stroke: "#2D8B5F", text: "#1D5C3F" },
-  amber:  { fill: "#FEF3DC", stroke: "#B8860B", text: "#7A5A07" },
-  red:    { fill: "#FCEBEB", stroke: "#C44D4D", text: "#8A2E2E" },
-};
-
-export default function App() {
-  const [nodes, setNodes] = useState([
-    { id: 1, label: "User message", sub: "Chat input", color: "teal" },
-    { id: 2, label: "CopilotKit runtime", sub: "API route → LangGraph", color: "purple" },
-    { id: 3, label: "Deep agent", sub: "Tools + middleware", color: "blue" },
-    { id: 4, label: "Widget renderer", sub: "Sandboxed iframe", color: "coral" },
-  ]);
-  const [selectedRamp, setSelectedRamp] = useState("teal");
-  const [newLabel, setNewLabel] = useState("");
-  const [newSub, setNewSub] = useState("");
-
-  const addNode = () => {
-    if (!newLabel) return;
-    setNodes(prev => [...prev, {
-      id: Date.now(), label: newLabel || "Node", sub: newSub || "", color: selectedRamp,
-    }]);
-    setNewLabel("");
-    setNewSub("");
-  };
-
-  const removeNode = (id) => setNodes(prev => prev.filter(n => n.id !== id));
-
-  // Calculate layout following skill rules
-  const padding = 40;
-  const gap = 34;
-  const nodePositions = nodes.map((node, i) => {
-    const hasSub = !!node.sub;
-    const h = hasSub ? 56 : 44;
-    const titleW = node.label.length * 8;   // 14px = 8px/char
-    const subW = node.sub ? node.sub.length * 7 : 0;  // 12px = 7px/char
-    const w = Math.max(titleW, subW) + 48;  // +48px padding
-    const y = i === 0 ? padding : null; // computed below
-    return { ...node, h, w, titleW, subW };
-  });
-
-  // Compute y positions
-  let currentY = padding;
-  nodePositions.forEach((n, i) => {
-    n.y = currentY;
-    n.x = 340 - n.w / 2; // center in 680px
-    currentY += n.h + gap;
-  });
-
-  const svgH = nodePositions.length > 0
-    ? nodePositions[nodePositions.length - 1].y + nodePositions[nodePositions.length - 1].h + padding
-    : 120;
-
-  return (
-    <div style={{ fontFamily: "system-ui, sans-serif", padding: 16 }}>
-      {/* Live SVG output */}
-      <svg width="100%" viewBox={\`0 0 680 \${svgH}\`} xmlns="http://www.w3.org/2000/svg"
-        style={{ background: "#fff", borderRadius: 8, border: "1px solid #e5e7eb" }}>
-        <defs>
-          <marker id="arr" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
-            <path d="M2 1L8 5L2 9" fill="none" stroke="context-stroke" strokeWidth="1.5" strokeLinecap="round" />
-          </marker>
-        </defs>
-        {/* Arrows */}
-        {nodePositions.slice(1).map((n, i) => {
-          const prev = nodePositions[i];
-          return <line key={"a"+i} x1={prev.x + prev.w/2} y1={prev.y + prev.h}
-            x2={n.x + n.w/2} y2={n.y} stroke="#9c9a92" strokeWidth="1.5" markerEnd="url(#arr)" />;
-        })}
-        {/* Nodes */}
-        {nodePositions.map(n => {
-          const c = ramps[n.color];
-          return (
-            <g key={n.id}>
-              <rect x={n.x} y={n.y} width={n.w} height={n.h} rx="8" fill={c.fill} stroke={c.stroke} strokeWidth="1" />
-              <text x={n.x + n.w/2} y={n.y + (n.sub ? 22 : n.h/2)} textAnchor="middle" dominantBaseline="central"
-                style={{ fontSize: 14, fontWeight: 500, fill: c.text }}>{n.label}</text>
-              {n.sub && <text x={n.x + n.w/2} y={n.y + 40} textAnchor="middle" dominantBaseline="central"
-                style={{ fontSize: 12, fill: c.text, opacity: 0.7 }}>{n.sub}</text>}
-            </g>
-          );
-        })}
-      </svg>
-
-      <div style={{ fontSize: 10, color: "#9c9a92", marginTop: 4, fontFamily: "monospace" }}>
-        viewBox="0 0 680 {svgH}" | {nodes.length} nodes | Height = lastY({nodePositions.length > 0 ? nodePositions[nodePositions.length-1].y : 0}) + nodeH({nodePositions.length > 0 ? nodePositions[nodePositions.length-1].h : 0}) + pad(40)
-      </div>
-
-      {/* Controls */}
-      <div style={{ marginTop: 12, display: "flex", gap: 8, flexWrap: "wrap", alignItems: "end" }}>
-        <div>
-          <div style={{ fontSize: 10, color: "#6b7280", marginBottom: 2 }}>Label</div>
-          <input value={newLabel} onChange={e => setNewLabel(e.target.value)} placeholder="Node title"
-            style={{ padding: "5px 8px", borderRadius: 6, border: "1px solid #d1d5db", fontSize: 12, width: 120 }} />
-        </div>
-        <div>
-          <div style={{ fontSize: 10, color: "#6b7280", marginBottom: 2 }}>Subtitle</div>
-          <input value={newSub} onChange={e => setNewSub(e.target.value)} placeholder="Optional"
-            style={{ padding: "5px 8px", borderRadius: 6, border: "1px solid #d1d5db", fontSize: 12, width: 100 }} />
-        </div>
-        <div>
-          <div style={{ fontSize: 10, color: "#6b7280", marginBottom: 2 }}>Color ramp</div>
-          <div style={{ display: "flex", gap: 3 }}>
-            {Object.keys(ramps).map(r => (
-              <button key={r} onClick={() => setSelectedRamp(r)} title={r} style={{
-                width: 18, height: 18, borderRadius: 4, border: selectedRamp === r ? \`2px solid \${ramps[r].stroke}\` : "1px solid #d1d5db",
-                background: ramps[r].fill, cursor: "pointer", padding: 0,
-              }} />
-            ))}
-          </div>
-        </div>
-        <button onClick={addNode} style={{
-          padding: "5px 12px", borderRadius: 6, border: "none", background: "#5B3FA0",
-          color: "#fff", cursor: "pointer", fontWeight: 600, fontSize: 12, alignSelf: "end",
-        }}>+ Add</button>
-      </div>
-
-      {/* Node list with remove */}
-      {nodes.length > 0 && (
-        <div style={{ marginTop: 8, display: "flex", gap: 4, flexWrap: "wrap" }}>
-          {nodes.map(n => (
-            <span key={n.id} style={{
-              padding: "2px 8px", borderRadius: 4, fontSize: 11,
-              background: ramps[n.color].fill, color: ramps[n.color].text,
-              border: \`1px solid \${ramps[n.color].stroke}\`, display: "flex", alignItems: "center", gap: 4,
-            }}>
-              {n.label}
-              <button onClick={() => removeNode(n.id)} style={{
-                background: "none", border: "none", cursor: "pointer", padding: 0,
-                fontSize: 12, color: ramps[n.color].text, opacity: 0.6, lineHeight: 1,
-              }}>x</button>
-            </span>
-          ))}
-        </div>
-      )}
     </div>
   );
 }`,

--- a/apps/notebook/src/content/chapters/06-widget-renderer.ts
+++ b/apps/notebook/src/content/chapters/06-widget-renderer.ts
@@ -12,184 +12,225 @@ export const fullFlow: Chapter = {
       id: "flow-overview",
       content: `# Putting It Together
 
-Now that you've seen each layer, let's trace the **complete flow** from a user message to a rendered visualization.
-
-## End-to-End: "Show me a solar system"
-
-| Step | Layer | What happens |
-|------|-------|-------------|
-| 1 | **Frontend** | User types "Show me a solar system" in CopilotKit chat |
-| 2 | **CopilotKit** | \`CopilotRuntime\` sends message to LangGraph agent via \`LangGraphHttpAgent\` |
-| 3 | **Deep Agent** | Agent acknowledges: "I'll create an interactive solar system for you." |
-| 4 | **Deep Agent** | Agent calls \`plan_visualization(approach="3D orbital simulation", technology="Three.js", ...)\` |
-| 5 | **CopilotKit** | \`useRenderTool("plan_visualization")\` renders \`<PlanCard>\` in the chat stream |
-| 6 | **Deep Agent** | Agent calls \`widgetRenderer({ title: "Solar System", html: "<div>..." })\` |
-| 7 | **CopilotKit** | \`useComponent("widgetRenderer")\` renders \`<WidgetRenderer>\` component |
-| 8 | **Widget Renderer** | Empty iframe shell assembled (Theme CSS + Bridge JS + Import Map) |
-| 9 | **Widget Renderer** | HTML streamed via \`postMessage\` → Idiomorph morphs the DOM |
-| 10 | **Widget Renderer** | \`<script type="module">\` loads Three.js from import map, creates scene |
-| 11 | **Widget Renderer** | Auto-resize reports final height → iframe fits content |
-| 12 | **Deep Agent** | Agent narrates: "The visualization shows planets orbiting the sun..." |`,
-    },
-    {
-      type: "markdown",
-      id: "flow-mcp-path",
-      content: `## MCP Skill Integration Path
-
-When the CopilotKit runtime has an MCP server configured, skills enhance the agent's output quality:
-
-1. Runtime connects to MCP server at startup (\`mcpApps.servers\` config)
-2. Agent can read skill resources (\`skills://master-agent-playbook\`)
-3. Agent follows skill rules: response decision tree, 3-layer pattern, SVG rules
-4. For external tools (Claude Desktop, Cursor), the MCP server also exposes:
-   - **Prompts**: Pre-composed skill instructions (\`create_widget\`, \`create_svg_diagram\`)
-   - **Tools**: \`assemble_document\` wraps HTML with the full design system
-
-The skills layer is what ensures consistent visual quality — without it, the agent would produce inconsistent styling and miss design system variables.`,
-    },
-    {
-      type: "markdown",
-      id: "flow-state-sync",
-      content: `## State Sync Flow
-
-For todo interactions, the state flows bidirectionally:
-
-**User edits a todo:**
-1. User clicks checkbox → \`agent.setState({ todos: updatedList })\`
-2. CopilotKit syncs new state to LangGraph agent backend
-3. Agent sees the update in its next tool call via \`runtime.state.todos\`
-
-**Agent adds a todo:**
-1. Agent calls \`manage_todos([...existingTodos, newTodo])\`
-2. LangGraph \`Command(update={todos: [...]})\` updates agent state
-3. CopilotKit syncs back to frontend → \`agent.state.todos\` updates
-4. React re-renders the todo list
-
-Both directions use the same state object — there's no separate frontend vs. backend state.`,
-    },
-    {
-      type: "code",
-      id: "flow-config",
-      language: "typescript",
-      filename: "Complete CopilotKit runtime configuration",
-      content: `// apps/app/src/app/api/copilotkit/route.ts
-const defaultAgent = new LangGraphHttpAgent({
-  deploymentUrl: process.env.LANGGRAPH_DEPLOYMENT_URL || "http://localhost:8123",
-  agentName: "sample_agent",
-});
-
-const runtime = new CopilotRuntime({
-  agents: { default: defaultAgent },
-  a2ui: { injectA2UITool: true },
-  mcpApps: {
-    servers: process.env.MCP_SERVER_URL ? [{
-      type: "http",
-      url: process.env.MCP_SERVER_URL,
-      serverId: "example_mcp_app",
-    }] : [],
-  },
-});
-
-// apps/agent/main.py
-agent = create_deep_agent(
-    model=ChatOpenAI(model="gpt-5.4-2026-03-05"),
-    tools=[query_data, plan_visualization, *todo_tools, generate_form],
-    middleware=[CopilotKitMiddleware()],
-    context_schema=AgentState,
-    skills=[str(Path(__file__).parent / "skills")],
-    checkpointer=BoundedMemorySaver(max_threads=200),
-    system_prompt="...",
-)`,
+Now let's trace the **complete flow** in one working demo. Type a message, and watch it flow through all four layers — ending with a real rendered widget in an iframe.`,
     },
     {
       type: "playground",
-      id: "flow-playground",
-      title: "Try it: Full Pipeline Simulation",
+      id: "flow-full-demo",
+      title: "Live: Complete end-to-end pipeline — type a message, get a widget",
       files: {
-        "/App.js": `import { useState, useEffect } from "react";
+        "/App.js": `import { useState, useRef, useEffect } from "react";
 
-// Simulates the complete end-to-end flow
-const pipeline = [
-  { layer: "Frontend", action: "User sends message", detail: '"Show me a solar system"', icon: "💬" },
-  { layer: "CopilotKit", action: "Routes to LangGraph agent", detail: "POST /api/copilotkit → localhost:8123", icon: "🔌" },
-  { layer: "Deep Agent", action: "Acknowledges request", detail: '"I\'ll create an interactive solar system visualization."', icon: "🧠" },
-  { layer: "Deep Agent", action: "Calls plan_visualization", detail: "approach: '3D orbital sim', tech: 'Three.js'", icon: "📋" },
-  { layer: "CopilotKit", action: "Renders PlanCard", detail: "useRenderTool renders component in chat", icon: "🔌" },
-  { layer: "Deep Agent", action: "Calls widgetRenderer", detail: "html: '<div id=\\"scene\\">...</div><script type=\\"module\\">...'", icon: "🧠" },
-  { layer: "Widget Renderer", action: "Assembles iframe shell", detail: "Theme CSS + Bridge JS + Import Map", icon: "🖼" },
-  { layer: "Widget Renderer", action: "Streams HTML via postMessage", detail: "Idiomorph morphs DOM, scripts execute sequentially", icon: "🖼" },
-  { layer: "Widget Renderer", action: "Auto-resize complete", detail: "Height: 450px, streaming settled", icon: "🖼" },
-  { layer: "Deep Agent", action: "Narrates result", detail: '"The visualization shows planets orbiting..."', icon: "🧠" },
-];
-
-const layerColors = {
-  "Frontend":        { bg: "#f0fdf4", border: "#a7f3d0", text: "#166534" },
-  "CopilotKit":      { bg: "#f5f3ff", border: "#c4b5fd", text: "#5b21b6" },
-  "Deep Agent":      { bg: "#eff6ff", border: "#93c5fd", text: "#1e40af" },
-  "Widget Renderer": { bg: "#fff7ed", border: "#fdba74", text: "#9a3412" },
+// Prompt → tool library: maps keywords to full widget HTML output
+const widgetLibrary = {
+  dashboard: {
+    plan: { approach: "Metrics dashboard with KPI cards and bar chart", technology: "HTML + CSS", keyElements: ["KPI metric cards", "Horizontal bar chart", "Animated entrances"] },
+    title: "Agent Dashboard",
+    html: \`<style>
+      body{font-family:system-ui,sans-serif;padding:20px;margin:0}
+      .g{display:grid;grid-template-columns:repeat(3,1fr);gap:10px;margin-bottom:16px}
+      .c{padding:12px;border-radius:12px;border:0.5px solid rgba(0,0,0,.12);animation:fadeUp .5s ease forwards;opacity:0}
+      .cl{font-size:11px;margin-bottom:2px}.cv{font-size:22px;font-weight:500}
+      .br{display:flex;align-items:center;gap:8px;margin:5px 0}.bl{width:80px;font-size:12px;color:#73726c;text-align:right}
+      .bt{flex:1;height:20px;background:#f7f6f3;border-radius:6px;overflow:hidden}
+      .bf{height:100%;border-radius:6px;animation:grow .8s ease forwards;transform-origin:left}
+      @keyframes grow{from{transform:scaleX(0)}to{transform:scaleX(1)}}
+      @keyframes fadeUp{from{opacity:0;transform:translateY(6px)}to{opacity:1;transform:translateY(0)}}
+    </style>
+    <div class="g">
+      <div class="c" style="background:#EDE9F5;animation-delay:.1s"><div class="cl" style="color:#5B3FA0">Requests</div><div class="cv" style="color:#5B3FA0">2.4k</div></div>
+      <div class="c" style="background:#E1F5EE;animation-delay:.2s"><div class="cl" style="color:#0F6E56">Uptime</div><div class="cv" style="color:#0F6E56">99.9%</div></div>
+      <div class="c" style="background:#E3EFFC;animation-delay:.3s"><div class="cl" style="color:#2663B3">P95</div><div class="cv" style="color:#2663B3">180ms</div></div>
+    </div>
+    <div style="font-size:14px;font-weight:500;margin-bottom:8px">Endpoint traffic</div>
+    <div class="br"><span class="bl">/api/chat</span><div class="bt"><div class="bf" style="width:82%;background:#5B3FA0"></div></div><span style="font-size:11px;color:#73726c">82%</span></div>
+    <div class="br"><span class="bl">/api/tools</span><div class="bt"><div class="bf" style="width:56%;background:#0F6E56;animation-delay:.1s"></div></div><span style="font-size:11px;color:#73726c">56%</span></div>
+    <div class="br"><span class="bl">/api/state</span><div class="bt"><div class="bf" style="width:34%;background:#2663B3;animation-delay:.2s"></div></div><span style="font-size:11px;color:#73726c">34%</span></div>\`,
+  },
+  chart: {
+    plan: { approach: "Animated donut chart showing language distribution", technology: "SVG + CSS animations", keyElements: ["SVG donut ring segments", "Animated arc drawing", "Legend with percentages"] },
+    title: "Language Distribution",
+    html: \`<style>
+      body{font-family:system-ui,sans-serif;padding:20px;margin:0}
+      .legend{display:flex;gap:16px;justify-content:center;margin-top:12px;flex-wrap:wrap}
+      .li{display:flex;align-items:center;gap:5px;font-size:12px;color:#73726c}
+      .dot{width:8px;height:8px;border-radius:2px}
+      circle{transition:stroke-dashoffset 1s ease}
+    </style>
+    <div style="text-align:center">
+      <svg width="180" height="180" viewBox="0 0 200 200">
+        <circle cx="100" cy="100" r="80" fill="none" stroke="#EDE9F5" stroke-width="24"/>
+        <circle cx="100" cy="100" r="80" fill="none" stroke="#5B3FA0" stroke-width="24"
+          stroke-dasharray="226 502" stroke-dashoffset="0" transform="rotate(-90 100 100)">
+          <animate attributeName="stroke-dashoffset" from="502" to="0" dur="1s" fill="freeze"/>
+        </circle>
+        <circle cx="100" cy="100" r="80" fill="none" stroke="#0F6E56" stroke-width="24"
+          stroke-dasharray="151 502" stroke-dashoffset="-226" transform="rotate(-90 100 100)">
+          <animate attributeName="stroke-dashoffset" from="-226" to="-226" dur="0.5s" fill="freeze"/>
+        </circle>
+        <circle cx="100" cy="100" r="80" fill="none" stroke="#2663B3" stroke-width="24"
+          stroke-dasharray="75 502" stroke-dashoffset="-377" transform="rotate(-90 100 100)"/>
+        <circle cx="100" cy="100" r="80" fill="none" stroke="#C44D4D" stroke-width="24"
+          stroke-dasharray="50 502" stroke-dashoffset="-452" transform="rotate(-90 100 100)"/>
+      </svg>
+      <div class="legend">
+        <span class="li"><span class="dot" style="background:#5B3FA0"></span>TypeScript 45%</span>
+        <span class="li"><span class="dot" style="background:#0F6E56"></span>Python 30%</span>
+        <span class="li"><span class="dot" style="background:#2663B3"></span>CSS 15%</span>
+        <span class="li"><span class="dot" style="background:#C44D4D"></span>Other 10%</span>
+      </div>
+    </div>\`,
+  },
+  diagram: {
+    plan: { approach: "Architecture flow diagram showing data path", technology: "Inline SVG (skill-guided)", keyElements: ["4 layered nodes with color ramps", "Directional arrows", "680px viewBox, responsive"] },
+    title: "Architecture Flow",
+    html: \`<svg width="100%" viewBox="0 0 680 370" xmlns="http://www.w3.org/2000/svg" style="display:block">
+      <defs><marker id="a" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto"><path d="M2 1L8 5L2 9" fill="none" stroke="context-stroke" stroke-width="1.5" stroke-linecap="round"/></marker></defs>
+      <line x1="340" y1="82" x2="340" y2="110" stroke="#9c9a92" stroke-width="1.5" marker-end="url(#a)"/>
+      <line x1="340" y1="166" x2="340" y2="200" stroke="#9c9a92" stroke-width="1.5" marker-end="url(#a)"/>
+      <line x1="340" y1="256" x2="340" y2="290" stroke="#9c9a92" stroke-width="1.5" marker-end="url(#a)"/>
+      <g><rect x="245" y="30" width="190" height="52" rx="8" fill="#E1F5EE" stroke="#0F6E56"/><text x="340" y="50" text-anchor="middle" dominant-baseline="central" style="font:500 14px system-ui;fill:#085041">User message</text><text x="340" y="68" text-anchor="middle" dominant-baseline="central" style="font:400 12px system-ui;fill:#085041;opacity:.7">Chat input</text></g>
+      <g><rect x="215" y="112" width="250" height="52" rx="8" fill="#EDE9F5" stroke="#5B3FA0"/><text x="340" y="132" text-anchor="middle" dominant-baseline="central" style="font:500 14px system-ui;fill:#3E2B6F">CopilotKit runtime</text><text x="340" y="150" text-anchor="middle" dominant-baseline="central" style="font:400 12px system-ui;fill:#3E2B6F;opacity:.7">LangGraphHttpAgent bridge</text></g>
+      <g><rect x="220" y="202" width="240" height="52" rx="8" fill="#E3EFFC" stroke="#2663B3"/><text x="340" y="222" text-anchor="middle" dominant-baseline="central" style="font:500 14px system-ui;fill:#1A4680">LangGraph deep agent</text><text x="340" y="240" text-anchor="middle" dominant-baseline="central" style="font:400 12px system-ui;fill:#1A4680;opacity:.7">Tools + skills + state</text></g>
+      <g><rect x="230" y="292" width="220" height="52" rx="8" fill="#FCE8E8" stroke="#C44D4D"/><text x="340" y="312" text-anchor="middle" dominant-baseline="central" style="font:500 14px system-ui;fill:#8A2E2E">Widget renderer</text><text x="340" y="330" text-anchor="middle" dominant-baseline="central" style="font:400 12px system-ui;fill:#8A2E2E;opacity:.7">Sandboxed iframe output</text></g>
+    </svg>\`,
+  },
 };
 
-export default function App() {
-  const [step, setStep] = useState(-1);
-  const [running, setRunning] = useState(false);
+const prompts = [
+  { text: "Show me a dashboard", key: "dashboard" },
+  { text: "Create a language chart", key: "chart" },
+  { text: "Draw the architecture", key: "diagram" },
+];
 
-  const run = async () => {
-    setRunning(true);
-    setStep(-1);
-    for (let i = 0; i < pipeline.length; i++) {
-      await new Promise(r => setTimeout(r, 700));
-      setStep(i);
-    }
-    setRunning(false);
+export default function App() {
+  const [input, setInput] = useState("");
+  const [log, setLog] = useState([]);
+  const [phase, setPhase] = useState("idle");
+  const [widgetHtml, setWidgetHtml] = useState("");
+  const iframeRef = useRef(null);
+  const bottomRef = useRef(null);
+
+  useEffect(() => { bottomRef.current?.scrollIntoView({ behavior: "smooth" }); }, [log, widgetHtml]);
+
+  useEffect(() => {
+    if (!iframeRef.current || !widgetHtml) return;
+    const doc = iframeRef.current.contentDocument;
+    if (!doc) return;
+    doc.open();
+    doc.write(\`<!DOCTYPE html><html><body style="margin:0">\${widgetHtml}</body></html>\`);
+    doc.close();
+  }, [widgetHtml]);
+
+  const send = async (promptKey) => {
+    const widget = widgetLibrary[promptKey];
+    if (!widget) return;
+    setLog([]);
+    setWidgetHtml("");
+    setInput("");
+
+    // 1. User message
+    setLog([{ type: "user", text: prompts.find(p => p.key === promptKey)?.text || input }]);
+    setPhase("ack");
+    await new Promise(r => setTimeout(r, 500));
+
+    // 2. Acknowledge
+    setLog(prev => [...prev, { type: "agent", text: "I'll create that for you." }]);
+    setPhase("plan");
+    await new Promise(r => setTimeout(r, 700));
+
+    // 3. Plan
+    setLog(prev => [...prev, { type: "plan", data: widget.plan }]);
+    setPhase("build");
+    await new Promise(r => setTimeout(r, 800));
+
+    // 4. Build — render actual widget
+    setLog(prev => [...prev, { type: "widget", title: widget.title }]);
+    setWidgetHtml(widget.html);
+    setPhase("narrate");
+    await new Promise(r => setTimeout(r, 1200));
+
+    // 5. Narrate
+    setLog(prev => [...prev, { type: "agent", text: "Here's the visualization. The data is rendered using the design system's CSS variables, so it supports dark mode automatically. Want me to modify anything?" }]);
+    setPhase("done");
   };
 
   return (
-    <div style={{ fontFamily: "system-ui, sans-serif", padding: 20 }}>
-      <h2 style={{ fontSize: 16, fontWeight: 700, marginBottom: 4 }}>
-        End-to-End Flow
-      </h2>
-      <p style={{ fontSize: 13, color: "#6b7280", marginBottom: 16 }}>
-        Watch a user message flow through all four layers.
-      </p>
-
-      <div style={{ display: "flex", flexDirection: "column", gap: 4, marginBottom: 16 }}>
-        {pipeline.map((s, i) => {
-          const active = i <= step;
-          const c = layerColors[s.layer];
-          return (
-            <div key={i} style={{
-              display: "flex", gap: 10, padding: "8px 12px", borderRadius: 8,
-              background: active ? c.bg : "#fafafa",
-              border: \`1px solid \${active ? c.border : "#f0f0f0"}\`,
-              opacity: active ? 1 : 0.3,
-              transition: "all 0.3s ease",
-              fontSize: 13,
-            }}>
-              <span style={{ fontSize: 16 }}>{s.icon}</span>
-              <div style={{ flex: 1 }}>
-                <div style={{ fontWeight: 600, color: active ? c.text : "#9ca3af" }}>
-                  {s.layer}: {s.action}
-                </div>
-                <div style={{
-                  fontSize: 11, fontFamily: "monospace",
-                  color: active ? "#6b7280" : "#d1d5db", marginTop: 2,
+    <div style={{ fontFamily: "system-ui, sans-serif", display: "flex", flexDirection: "column", height: 520 }}>
+      {/* Chat area */}
+      <div style={{ flex: 1, overflow: "auto", padding: 16, display: "flex", flexDirection: "column", gap: 8 }}>
+        {log.length === 0 && (
+          <div style={{ textAlign: "center", marginTop: 30 }}>
+            <div style={{ color: "#374151", fontSize: 15, fontWeight: 600, marginBottom: 12 }}>Try a prompt:</div>
+            <div style={{ display: "flex", gap: 8, justifyContent: "center", flexWrap: "wrap" }}>
+              {prompts.map(p => (
+                <button key={p.key} onClick={() => send(p.key)} style={{
+                  padding: "8px 16px", borderRadius: 20, border: "1px solid #e5e7eb",
+                  background: "#fff", cursor: "pointer", fontSize: 13, color: "#374151",
+                  transition: "all 0.15s",
                 }}>
-                  {s.detail}
-                </div>
-              </div>
+                  {p.text}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {log.map((msg, i) => {
+          if (msg.type === "user") return (
+            <div key={i} style={{ alignSelf: "flex-end", padding: "8px 14px", borderRadius: "12px 12px 4px 12px", background: "#5B3FA0", color: "#fff", fontSize: 13, maxWidth: "80%" }}>
+              {msg.text}
             </div>
           );
+          if (msg.type === "agent") return (
+            <div key={i} style={{ padding: "8px 14px", borderRadius: "12px 12px 12px 4px", background: "#f9fafb", border: "1px solid #e5e7eb", fontSize: 13, color: "#374151", maxWidth: "85%", lineHeight: 1.5 }}>
+              {msg.text}
+            </div>
+          );
+          if (msg.type === "plan") return (
+            <div key={i} style={{ padding: 12, borderRadius: 10, background: "#EDE9F5", border: "1px solid #c4b5fd", maxWidth: "85%", fontSize: 12 }}>
+              <div style={{ fontSize: 10, fontWeight: 600, color: "#5B3FA0", textTransform: "uppercase", marginBottom: 4 }}>plan_visualization</div>
+              <div style={{ fontWeight: 600, color: "#3E2B6F" }}>{msg.data.approach}</div>
+              <div style={{ color: "#5B3FA0", fontSize: 11, marginTop: 2 }}>Tech: {msg.data.technology}</div>
+            </div>
+          );
+          if (msg.type === "widget") return (
+            <div key={i} style={{ borderRadius: 10, overflow: "hidden", border: "1px solid #e5e7eb", maxWidth: "95%" }}>
+              <div style={{ padding: "6px 12px", background: "#f9fafb", borderBottom: "1px solid #e5e7eb", fontSize: 11, fontWeight: 600, color: "#5B3FA0" }}>
+                widgetRenderer: {msg.title}
+              </div>
+              <iframe ref={iframeRef} sandbox="allow-scripts"
+                style={{ width: "100%", height: 230, border: "none", display: "block" }} />
+            </div>
+          );
+          return null;
         })}
-      </div>
 
-      <button onClick={run} disabled={running} style={{
-        padding: "8px 16px", borderRadius: 8, border: "none",
-        background: running ? "#d1d5db" : "linear-gradient(135deg, #9599CC, #1B936F)",
-        color: "#fff", cursor: running ? "default" : "pointer",
-        fontWeight: 600, fontSize: 13,
-      }}>
-        {running ? "Running..." : "Trace Full Pipeline"}
-      </button>
+        {phase !== "idle" && phase !== "done" && (
+          <div style={{ display: "flex", alignItems: "center", gap: 6, fontSize: 12, color: "#5B3FA0" }}>
+            <span style={{ width: 6, height: 6, borderRadius: "50%", background: "#5B3FA0", animation: "pulse 1s infinite" }} />
+            {phase === "ack" ? "Agent thinking..." : phase === "plan" ? "Planning visualization..." : phase === "build" ? "Rendering widget..." : "Writing narration..."}
+          </div>
+        )}
+        <div ref={bottomRef} />
+      </div>
+      <style>{"@keyframes pulse{0%,100%{opacity:1}50%{opacity:.3}}"}</style>
+
+      {/* Input bar + quick prompts */}
+      <div style={{ padding: 12, borderTop: "1px solid #e5e7eb", display: "flex", gap: 8 }}>
+        {phase === "done" && (
+          <div style={{ display: "flex", gap: 6, flex: 1 }}>
+            {prompts.map(p => (
+              <button key={p.key} onClick={() => send(p.key)} style={{
+                flex: 1, padding: "10px", borderRadius: 8, border: "1px solid #e5e7eb",
+                background: "#fff", cursor: "pointer", fontSize: 12, fontWeight: 600, color: "#374151",
+              }}>
+                {p.text}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
     </div>
   );
 }`,
@@ -200,15 +241,15 @@ export default function App() {
       id: "flow-extend",
       content: `## Extending the Template
 
-To add your own domain to OpenGenerativeUI:
+To add your own domain:
 
-1. **Define state** — Add fields to \`AgentState\` in \`todos.py\` (or create a new schema)
-2. **Create tools** — Write LangGraph tools that return \`Command(update={...})\` to modify state
-3. **Register components** — Use \`useComponent()\` in the frontend to register UI for agent tool calls
-4. **Write skills** — Add \`.txt\` playbooks to guide the agent's visual output quality
-5. **Configure the system prompt** — Define your mandatory workflow steps
+1. **Define state** — Add fields to \`AgentState\` in Python
+2. **Create tools** — Return \`Command(update={...})\` to modify state
+3. **Register components** — Use \`useComponent()\` for agent-renderable UI
+4. **Write skills** — Add \`.txt\` playbooks for visual quality
+5. **Configure the system prompt** — Define your mandatory workflow
 
-The todo list is the starting point — replace it with your domain (project tracker, inventory, scheduling, etc.) while keeping the same CopilotKit v2 state pattern.`,
+The todo list is the starting point — replace it with your domain while keeping the same CopilotKit v2 state pattern.`,
     },
   ],
 };

--- a/apps/notebook/src/content/chapters/06-widget-renderer.ts
+++ b/apps/notebook/src/content/chapters/06-widget-renderer.ts
@@ -1,197 +1,195 @@
 import type { Chapter } from "@/lib/types";
 
-export const widgetRenderer: Chapter = {
-  id: "widget-renderer",
-  title: "Widget Renderer",
+export const fullFlow: Chapter = {
+  id: "full-flow",
+  title: "Putting It Together",
   description:
-    "The sandboxed iframe that renders agent-generated HTML, SVG, and 3D content.",
-  icon: "🖼",
+    "The complete end-to-end flow from user message to rendered visualization.",
+  icon: "🔗",
   cells: [
     {
       type: "markdown",
-      id: "widget-concept",
-      content: `# Widget Renderer
+      id: "flow-overview",
+      content: `# Putting It Together
 
-The Widget Renderer is the most flexible generative UI component. It takes **arbitrary HTML/CSS/JS** from the agent and renders it in a **sandboxed iframe**. This is what enables the agent to produce:
+Now that you've seen each layer, let's trace the **complete flow** from a user message to a rendered visualization.
 
-- 3D scenes (Three.js)
-- Data visualizations (D3, Chart.js)
-- Animated graphics (GSAP)
-- Interactive SVG diagrams
-- Custom form UIs
-- Anything expressible in HTML
+## End-to-End: "Show me a solar system"
 
-## Security Model
-
-The iframe is sandboxed with \`allow-scripts allow-same-origin\`, meaning:
-- Scripts can run inside the iframe
-- The iframe cannot navigate the parent page
-- The iframe cannot access parent cookies or storage
-- Communication happens only through \`postMessage\``,
-    },
-    {
-      type: "code",
-      id: "widget-bridge",
-      language: "typescript",
-      filename: "Bridge API (injected into iframe)",
-      content: `// The bridge script injected into every widget iframe:
-
-// Send a new prompt to the agent from inside the widget
-window.sendPrompt = (text: string) => {
-  window.parent.postMessage(
-    { type: "send-prompt", prompt: text },
-    "*"
-  );
-};
-
-// Open an external link (handled by parent)
-window.openLink = (url: string) => {
-  window.parent.postMessage(
-    { type: "open-link", url },
-    "*"
-  );
-};
-
-// Auto-resize: report height changes to parent
-const observer = new ResizeObserver(() => {
-  window.parent.postMessage(
-    { type: "resize", height: document.body.scrollHeight },
-    "*"
-  );
-});
-observer.observe(document.body);`,
+| Step | Layer | What happens |
+|------|-------|-------------|
+| 1 | **Frontend** | User types "Show me a solar system" in CopilotKit chat |
+| 2 | **CopilotKit** | \`CopilotRuntime\` sends message to LangGraph agent via \`LangGraphHttpAgent\` |
+| 3 | **Deep Agent** | Agent acknowledges: "I'll create an interactive solar system for you." |
+| 4 | **Deep Agent** | Agent calls \`plan_visualization(approach="3D orbital simulation", technology="Three.js", ...)\` |
+| 5 | **CopilotKit** | \`useRenderTool("plan_visualization")\` renders \`<PlanCard>\` in the chat stream |
+| 6 | **Deep Agent** | Agent calls \`widgetRenderer({ title: "Solar System", html: "<div>..." })\` |
+| 7 | **CopilotKit** | \`useComponent("widgetRenderer")\` renders \`<WidgetRenderer>\` component |
+| 8 | **Widget Renderer** | Empty iframe shell assembled (Theme CSS + Bridge JS + Import Map) |
+| 9 | **Widget Renderer** | HTML streamed via \`postMessage\` → Idiomorph morphs the DOM |
+| 10 | **Widget Renderer** | \`<script type="module">\` loads Three.js from import map, creates scene |
+| 11 | **Widget Renderer** | Auto-resize reports final height → iframe fits content |
+| 12 | **Deep Agent** | Agent narrates: "The visualization shows planets orbiting the sun..." |`,
     },
     {
       type: "markdown",
-      id: "widget-streaming",
-      content: `## Streaming Updates
+      id: "flow-mcp-path",
+      content: `## MCP Skill Integration Path
 
-When the agent streams HTML content, the widget renderer uses **Idiomorph** for efficient DOM diffing. Instead of replacing the entire iframe content on each chunk, Idiomorph morphs the existing DOM to match the new HTML — preserving interactive state, animations, and scroll position.
+When the CopilotKit runtime has an MCP server configured, skills enhance the agent's output quality:
 
-The flow works like this:
+1. Runtime connects to MCP server at startup (\`mcpApps.servers\` config)
+2. Agent can read skill resources (\`skills://master-agent-playbook\`)
+3. Agent follows skill rules: response decision tree, 3-layer pattern, SVG rules
+4. For external tools (Claude Desktop, Cursor), the MCP server also exposes:
+   - **Prompts**: Pre-composed skill instructions (\`create_widget\`, \`create_svg_diagram\`)
+   - **Tools**: \`assemble_document\` wraps HTML with the full design system
 
-1. Agent starts streaming HTML → Empty iframe shell loaded
-2. Each HTML chunk → Sent via \`postMessage\` to the iframe
-3. Inside the iframe → Idiomorph morphs the DOM (minimal changes)
-4. Agent finishes → Final HTML applied, export overlay appears
+The skills layer is what ensures consistent visual quality — without it, the agent would produce inconsistent styling and miss design system variables.`,
+    },
+    {
+      type: "markdown",
+      id: "flow-state-sync",
+      content: `## State Sync Flow
 
-## Import Maps
+For todo interactions, the state flows bidirectionally:
 
-The iframe includes import maps so widgets can use ES modules directly:`,
+**User edits a todo:**
+1. User clicks checkbox → \`agent.setState({ todos: updatedList })\`
+2. CopilotKit syncs new state to LangGraph agent backend
+3. Agent sees the update in its next tool call via \`runtime.state.todos\`
+
+**Agent adds a todo:**
+1. Agent calls \`manage_todos([...existingTodos, newTodo])\`
+2. LangGraph \`Command(update={todos: [...]})\` updates agent state
+3. CopilotKit syncs back to frontend → \`agent.state.todos\` updates
+4. React re-renders the todo list
+
+Both directions use the same state object — there's no separate frontend vs. backend state.`,
     },
     {
       type: "code",
-      id: "widget-imports",
-      language: "html",
-      filename: "Import map (injected into iframe head)",
-      content: `<script type="importmap">
-{
-  "imports": {
-    "three": "https://esm.sh/three@0.170.0",
-    "three/addons/": "https://esm.sh/three@0.170.0/examples/jsm/",
-    "gsap": "https://esm.sh/gsap@3.12.7",
-    "d3": "https://esm.sh/d3@7.9.0",
-    "chart.js": "https://esm.sh/chart.js@4.4.7",
-    "chart.js/auto": "https://esm.sh/chart.js@4.4.7/auto"
-  }
-}
-</script>`,
+      id: "flow-config",
+      language: "typescript",
+      filename: "Complete CopilotKit runtime configuration",
+      content: `// apps/app/src/app/api/copilotkit/route.ts
+const defaultAgent = new LangGraphHttpAgent({
+  deploymentUrl: process.env.LANGGRAPH_DEPLOYMENT_URL || "http://localhost:8123",
+  agentName: "sample_agent",
+});
+
+const runtime = new CopilotRuntime({
+  agents: { default: defaultAgent },
+  a2ui: { injectA2UITool: true },
+  mcpApps: {
+    servers: process.env.MCP_SERVER_URL ? [{
+      type: "http",
+      url: process.env.MCP_SERVER_URL,
+      serverId: "example_mcp_app",
+    }] : [],
+  },
+});
+
+// apps/agent/main.py
+agent = create_deep_agent(
+    model=ChatOpenAI(model="gpt-5.4-2026-03-05"),
+    tools=[query_data, plan_visualization, *todo_tools, generate_form],
+    middleware=[CopilotKitMiddleware()],
+    context_schema=AgentState,
+    skills=[str(Path(__file__).parent / "skills")],
+    checkpointer=BoundedMemorySaver(max_threads=200),
+    system_prompt="...",
+)`,
     },
     {
       type: "playground",
-      id: "widget-playground",
-      title: "Try it: Mini Widget Renderer",
+      id: "flow-playground",
+      title: "Try it: Full Pipeline Simulation",
       files: {
-        "/App.js": `import { useState, useRef, useEffect } from "react";
+        "/App.js": `import { useState, useEffect } from "react";
 
-const defaultHTML = \`<div style="font-family: 'Plus Jakarta Sans', sans-serif; padding: 24px;">
-  <h2 style="font-size: 20px; font-weight: 700;
-    background: linear-gradient(135deg, #9599CC, #1B936F);
-    -webkit-background-clip: text; -webkit-text-fill-color: transparent;">
-    Hello from the Widget!
-  </h2>
-  <p style="color: #6b7280; font-size: 14px;">
-    This HTML is rendered in an iframe, just like the real widget renderer.
-  </p>
-  <div style="display: flex; gap: 8px; margin-top: 16px;">
-    <div style="width: 60px; height: 60px; border-radius: 12px;
-      background: linear-gradient(135deg, #BEC2FF, #85E0CE);
-      animation: pulse 2s ease-in-out infinite;" />
-    <div style="width: 60px; height: 60px; border-radius: 12px;
-      background: linear-gradient(135deg, #85E0CE, #BEC2FF);
-      animation: pulse 2s ease-in-out infinite 0.3s;" />
-    <div style="width: 60px; height: 60px; border-radius: 12px;
-      background: linear-gradient(135deg, #9599CC, #A8E9DC);
-      animation: pulse 2s ease-in-out infinite 0.6s;" />
-  </div>
-  <style>
-    @keyframes pulse {
-      0%, 100% { transform: scale(1); opacity: 1; }
-      50% { transform: scale(0.9); opacity: 0.7; }
-    }
-  </style>
-</div>\`;
+// Simulates the complete end-to-end flow
+const pipeline = [
+  { layer: "Frontend", action: "User sends message", detail: '"Show me a solar system"', icon: "💬" },
+  { layer: "CopilotKit", action: "Routes to LangGraph agent", detail: "POST /api/copilotkit → localhost:8123", icon: "🔌" },
+  { layer: "Deep Agent", action: "Acknowledges request", detail: '"I\'ll create an interactive solar system visualization."', icon: "🧠" },
+  { layer: "Deep Agent", action: "Calls plan_visualization", detail: "approach: '3D orbital sim', tech: 'Three.js'", icon: "📋" },
+  { layer: "CopilotKit", action: "Renders PlanCard", detail: "useRenderTool renders component in chat", icon: "🔌" },
+  { layer: "Deep Agent", action: "Calls widgetRenderer", detail: "html: '<div id=\\"scene\\">...</div><script type=\\"module\\">...'", icon: "🧠" },
+  { layer: "Widget Renderer", action: "Assembles iframe shell", detail: "Theme CSS + Bridge JS + Import Map", icon: "🖼" },
+  { layer: "Widget Renderer", action: "Streams HTML via postMessage", detail: "Idiomorph morphs DOM, scripts execute sequentially", icon: "🖼" },
+  { layer: "Widget Renderer", action: "Auto-resize complete", detail: "Height: 450px, streaming settled", icon: "🖼" },
+  { layer: "Deep Agent", action: "Narrates result", detail: '"The visualization shows planets orbiting..."', icon: "🧠" },
+];
+
+const layerColors = {
+  "Frontend":        { bg: "#f0fdf4", border: "#a7f3d0", text: "#166534" },
+  "CopilotKit":      { bg: "#f5f3ff", border: "#c4b5fd", text: "#5b21b6" },
+  "Deep Agent":      { bg: "#eff6ff", border: "#93c5fd", text: "#1e40af" },
+  "Widget Renderer": { bg: "#fff7ed", border: "#fdba74", text: "#9a3412" },
+};
 
 export default function App() {
-  const [html, setHtml] = useState(defaultHTML);
-  const iframeRef = useRef(null);
+  const [step, setStep] = useState(-1);
+  const [running, setRunning] = useState(false);
 
-  useEffect(() => {
-    if (!iframeRef.current) return;
-    const doc = iframeRef.current.contentDocument;
-    if (!doc) return;
-    doc.open();
-    doc.write(\`<!DOCTYPE html>
-<html>
-<head>
-  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
-</head>
-<body style="margin:0;background:transparent;">\${html}</body>
-</html>\`);
-    doc.close();
-  }, [html]);
+  const run = async () => {
+    setRunning(true);
+    setStep(-1);
+    for (let i = 0; i < pipeline.length; i++) {
+      await new Promise(r => setTimeout(r, 700));
+      setStep(i);
+    }
+    setRunning(false);
+  };
 
   return (
-    <div style={{ fontFamily: "'Plus Jakarta Sans', sans-serif" }}>
-      <div style={{ display: "flex", flexDirection: "column", gap: 0 }}>
-        <div style={{ flex: 1 }}>
-          <div style={{
-            padding: "8px 12px", fontSize: 12, fontWeight: 600,
-            background: "#f9fafb", borderBottom: "1px solid #e5e7eb",
-            color: "#6b7280",
-          }}>
-            Edit HTML
-          </div>
-          <textarea
-            value={html}
-            onChange={(e) => setHtml(e.target.value)}
-            style={{
-              width: "100%", height: 180, padding: 12, border: "none",
-              fontFamily: "'SF Mono', 'Fira Code', monospace", fontSize: 12,
-              lineHeight: 1.6, resize: "none", outline: "none",
-              background: "#fff",
-            }}
-          />
-        </div>
-        <div style={{ flex: 1 }}>
-          <div style={{
-            padding: "8px 12px", fontSize: 12, fontWeight: 600,
-            background: "#f9fafb", borderBottom: "1px solid #e5e7eb",
-            borderTop: "1px solid #e5e7eb",
-            color: "#6b7280",
-          }}>
-            Preview (sandboxed iframe)
-          </div>
-          <iframe
-            ref={iframeRef}
-            sandbox="allow-scripts"
-            style={{
-              width: "100%", height: 200, border: "none",
-              background: "#fff",
-            }}
-          />
-        </div>
+    <div style={{ fontFamily: "system-ui, sans-serif", padding: 20 }}>
+      <h2 style={{ fontSize: 16, fontWeight: 700, marginBottom: 4 }}>
+        End-to-End Flow
+      </h2>
+      <p style={{ fontSize: 13, color: "#6b7280", marginBottom: 16 }}>
+        Watch a user message flow through all four layers.
+      </p>
+
+      <div style={{ display: "flex", flexDirection: "column", gap: 4, marginBottom: 16 }}>
+        {pipeline.map((s, i) => {
+          const active = i <= step;
+          const c = layerColors[s.layer];
+          return (
+            <div key={i} style={{
+              display: "flex", gap: 10, padding: "8px 12px", borderRadius: 8,
+              background: active ? c.bg : "#fafafa",
+              border: \`1px solid \${active ? c.border : "#f0f0f0"}\`,
+              opacity: active ? 1 : 0.3,
+              transition: "all 0.3s ease",
+              fontSize: 13,
+            }}>
+              <span style={{ fontSize: 16 }}>{s.icon}</span>
+              <div style={{ flex: 1 }}>
+                <div style={{ fontWeight: 600, color: active ? c.text : "#9ca3af" }}>
+                  {s.layer}: {s.action}
+                </div>
+                <div style={{
+                  fontSize: 11, fontFamily: "monospace",
+                  color: active ? "#6b7280" : "#d1d5db", marginTop: 2,
+                }}>
+                  {s.detail}
+                </div>
+              </div>
+            </div>
+          );
+        })}
       </div>
+
+      <button onClick={run} disabled={running} style={{
+        padding: "8px 16px", borderRadius: 8, border: "none",
+        background: running ? "#d1d5db" : "linear-gradient(135deg, #9599CC, #1B936F)",
+        color: "#fff", cursor: running ? "default" : "pointer",
+        fontWeight: 600, fontSize: 13,
+      }}>
+        {running ? "Running..." : "Trace Full Pipeline"}
+      </button>
     </div>
   );
 }`,
@@ -199,20 +197,18 @@ export default function App() {
     },
     {
       type: "markdown",
-      id: "widget-conclusion",
-      content: `## What's Next?
+      id: "flow-extend",
+      content: `## Extending the Template
 
-You've now seen the core building blocks of OpenGenerativeUI:
+To add your own domain to OpenGenerativeUI:
 
-1. **Agent State** — State lives in the agent, syncs bidirectionally
-2. **Generative UI** — Agent renders React components, not just text
-3. **CopilotKit Hooks** — \`useAgent\`, \`useComponent\`, \`useFrontendTool\`, and more
-4. **Frontend Tools** — Agent calls JavaScript in the browser
-5. **Widget Renderer** — Sandboxed iframe for arbitrary HTML/SVG/3D content
+1. **Define state** — Add fields to \`AgentState\` in \`todos.py\` (or create a new schema)
+2. **Create tools** — Write LangGraph tools that return \`Command(update={...})\` to modify state
+3. **Register components** — Use \`useComponent()\` in the frontend to register UI for agent tool calls
+4. **Write skills** — Add \`.txt\` playbooks to guide the agent's visual output quality
+5. **Configure the system prompt** — Define your mandatory workflow steps
 
-To get started with your own project, fork the repo and follow the setup instructions in the README. The todo list is a great starting point — extend it with categories, priorities, due dates, or replace it entirely with your own domain.
-
-Happy building!`,
+The todo list is the starting point — replace it with your domain (project tracker, inventory, scheduling, etc.) while keeping the same CopilotKit v2 state pattern.`,
     },
   ],
 };

--- a/apps/notebook/src/content/chapters/06-widget-renderer.ts
+++ b/apps/notebook/src/content/chapters/06-widget-renderer.ts
@@ -1,0 +1,218 @@
+import type { Chapter } from "@/lib/types";
+
+export const widgetRenderer: Chapter = {
+  id: "widget-renderer",
+  title: "Widget Renderer",
+  description:
+    "The sandboxed iframe that renders agent-generated HTML, SVG, and 3D content.",
+  icon: "🖼",
+  cells: [
+    {
+      type: "markdown",
+      id: "widget-concept",
+      content: `# Widget Renderer
+
+The Widget Renderer is the most flexible generative UI component. It takes **arbitrary HTML/CSS/JS** from the agent and renders it in a **sandboxed iframe**. This is what enables the agent to produce:
+
+- 3D scenes (Three.js)
+- Data visualizations (D3, Chart.js)
+- Animated graphics (GSAP)
+- Interactive SVG diagrams
+- Custom form UIs
+- Anything expressible in HTML
+
+## Security Model
+
+The iframe is sandboxed with \`allow-scripts allow-same-origin\`, meaning:
+- Scripts can run inside the iframe
+- The iframe cannot navigate the parent page
+- The iframe cannot access parent cookies or storage
+- Communication happens only through \`postMessage\``,
+    },
+    {
+      type: "code",
+      id: "widget-bridge",
+      language: "typescript",
+      filename: "Bridge API (injected into iframe)",
+      content: `// The bridge script injected into every widget iframe:
+
+// Send a new prompt to the agent from inside the widget
+window.sendPrompt = (text: string) => {
+  window.parent.postMessage(
+    { type: "send-prompt", prompt: text },
+    "*"
+  );
+};
+
+// Open an external link (handled by parent)
+window.openLink = (url: string) => {
+  window.parent.postMessage(
+    { type: "open-link", url },
+    "*"
+  );
+};
+
+// Auto-resize: report height changes to parent
+const observer = new ResizeObserver(() => {
+  window.parent.postMessage(
+    { type: "resize", height: document.body.scrollHeight },
+    "*"
+  );
+});
+observer.observe(document.body);`,
+    },
+    {
+      type: "markdown",
+      id: "widget-streaming",
+      content: `## Streaming Updates
+
+When the agent streams HTML content, the widget renderer uses **Idiomorph** for efficient DOM diffing. Instead of replacing the entire iframe content on each chunk, Idiomorph morphs the existing DOM to match the new HTML — preserving interactive state, animations, and scroll position.
+
+The flow works like this:
+
+1. Agent starts streaming HTML → Empty iframe shell loaded
+2. Each HTML chunk → Sent via \`postMessage\` to the iframe
+3. Inside the iframe → Idiomorph morphs the DOM (minimal changes)
+4. Agent finishes → Final HTML applied, export overlay appears
+
+## Import Maps
+
+The iframe includes import maps so widgets can use ES modules directly:`,
+    },
+    {
+      type: "code",
+      id: "widget-imports",
+      language: "html",
+      filename: "Import map (injected into iframe head)",
+      content: `<script type="importmap">
+{
+  "imports": {
+    "three": "https://esm.sh/three@0.170.0",
+    "three/addons/": "https://esm.sh/three@0.170.0/examples/jsm/",
+    "gsap": "https://esm.sh/gsap@3.12.7",
+    "d3": "https://esm.sh/d3@7.9.0",
+    "chart.js": "https://esm.sh/chart.js@4.4.7",
+    "chart.js/auto": "https://esm.sh/chart.js@4.4.7/auto"
+  }
+}
+</script>`,
+    },
+    {
+      type: "playground",
+      id: "widget-playground",
+      title: "Try it: Mini Widget Renderer",
+      files: {
+        "/App.js": `import { useState, useRef, useEffect } from "react";
+
+const defaultHTML = \`<div style="font-family: 'Plus Jakarta Sans', sans-serif; padding: 24px;">
+  <h2 style="font-size: 20px; font-weight: 700;
+    background: linear-gradient(135deg, #9599CC, #1B936F);
+    -webkit-background-clip: text; -webkit-text-fill-color: transparent;">
+    Hello from the Widget!
+  </h2>
+  <p style="color: #6b7280; font-size: 14px;">
+    This HTML is rendered in an iframe, just like the real widget renderer.
+  </p>
+  <div style="display: flex; gap: 8px; margin-top: 16px;">
+    <div style="width: 60px; height: 60px; border-radius: 12px;
+      background: linear-gradient(135deg, #BEC2FF, #85E0CE);
+      animation: pulse 2s ease-in-out infinite;" />
+    <div style="width: 60px; height: 60px; border-radius: 12px;
+      background: linear-gradient(135deg, #85E0CE, #BEC2FF);
+      animation: pulse 2s ease-in-out infinite 0.3s;" />
+    <div style="width: 60px; height: 60px; border-radius: 12px;
+      background: linear-gradient(135deg, #9599CC, #A8E9DC);
+      animation: pulse 2s ease-in-out infinite 0.6s;" />
+  </div>
+  <style>
+    @keyframes pulse {
+      0%, 100% { transform: scale(1); opacity: 1; }
+      50% { transform: scale(0.9); opacity: 0.7; }
+    }
+  </style>
+</div>\`;
+
+export default function App() {
+  const [html, setHtml] = useState(defaultHTML);
+  const iframeRef = useRef(null);
+
+  useEffect(() => {
+    if (!iframeRef.current) return;
+    const doc = iframeRef.current.contentDocument;
+    if (!doc) return;
+    doc.open();
+    doc.write(\`<!DOCTYPE html>
+<html>
+<head>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+</head>
+<body style="margin:0;background:transparent;">\${html}</body>
+</html>\`);
+    doc.close();
+  }, [html]);
+
+  return (
+    <div style={{ fontFamily: "'Plus Jakarta Sans', sans-serif" }}>
+      <div style={{ display: "flex", flexDirection: "column", gap: 0 }}>
+        <div style={{ flex: 1 }}>
+          <div style={{
+            padding: "8px 12px", fontSize: 12, fontWeight: 600,
+            background: "#f9fafb", borderBottom: "1px solid #e5e7eb",
+            color: "#6b7280",
+          }}>
+            Edit HTML
+          </div>
+          <textarea
+            value={html}
+            onChange={(e) => setHtml(e.target.value)}
+            style={{
+              width: "100%", height: 180, padding: 12, border: "none",
+              fontFamily: "'SF Mono', 'Fira Code', monospace", fontSize: 12,
+              lineHeight: 1.6, resize: "none", outline: "none",
+              background: "#fff",
+            }}
+          />
+        </div>
+        <div style={{ flex: 1 }}>
+          <div style={{
+            padding: "8px 12px", fontSize: 12, fontWeight: 600,
+            background: "#f9fafb", borderBottom: "1px solid #e5e7eb",
+            borderTop: "1px solid #e5e7eb",
+            color: "#6b7280",
+          }}>
+            Preview (sandboxed iframe)
+          </div>
+          <iframe
+            ref={iframeRef}
+            sandbox="allow-scripts"
+            style={{
+              width: "100%", height: 200, border: "none",
+              background: "#fff",
+            }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}`,
+      },
+    },
+    {
+      type: "markdown",
+      id: "widget-conclusion",
+      content: `## What's Next?
+
+You've now seen the core building blocks of OpenGenerativeUI:
+
+1. **Agent State** — State lives in the agent, syncs bidirectionally
+2. **Generative UI** — Agent renders React components, not just text
+3. **CopilotKit Hooks** — \`useAgent\`, \`useComponent\`, \`useFrontendTool\`, and more
+4. **Frontend Tools** — Agent calls JavaScript in the browser
+5. **Widget Renderer** — Sandboxed iframe for arbitrary HTML/SVG/3D content
+
+To get started with your own project, fork the repo and follow the setup instructions in the README. The todo list is a great starting point — extend it with categories, priorities, due dates, or replace it entirely with your own domain.
+
+Happy building!`,
+    },
+  ],
+};

--- a/apps/notebook/src/content/chapters/06-widget-renderer.ts
+++ b/apps/notebook/src/content/chapters/06-widget-renderer.ts
@@ -12,7 +12,7 @@ export const fullFlow: Chapter = {
       id: "flow-overview",
       content: `# Putting It Together
 
-Now let's trace the **complete flow** in one working demo. Type a message, and watch it flow through all four layers — ending with a real rendered widget in an iframe.`,
+Now let's trace the **complete flow** in one working demo. Pick a prompt, and watch it flow through all three layers — ending with a real rendered widget in an iframe.`,
     },
     {
       type: "playground",
@@ -246,8 +246,7 @@ To add your own domain:
 1. **Define state** — Add fields to \`AgentState\` in Python
 2. **Create tools** — Return \`Command(update={...})\` to modify state
 3. **Register components** — Use \`useComponent()\` for agent-renderable UI
-4. **Write skills** — Add \`.txt\` playbooks for visual quality
-5. **Configure the system prompt** — Define your mandatory workflow
+4. **Configure the system prompt** — Define your mandatory workflow
 
 The todo list is the starting point — replace it with your domain while keeping the same CopilotKit v2 state pattern.`,
     },

--- a/apps/notebook/src/content/index.ts
+++ b/apps/notebook/src/content/index.ts
@@ -2,13 +2,15 @@ import { introduction } from "./chapters/01-introduction";
 import { widgetRenderer } from "./chapters/02-agent-state";
 import { copilotKitIntegration } from "./chapters/03-generative-ui";
 import { deepAgent } from "./chapters/04-copilotkit-hooks";
+import { agentSkills } from "./chapters/05-frontend-tools";
 import { fullFlow } from "./chapters/06-widget-renderer";
 import type { Chapter } from "@/lib/types";
 
 export const chapters: Chapter[] = [
   introduction,
-  widgetRenderer,
-  copilotKitIntegration,
   deepAgent,
+  agentSkills,
+  copilotKitIntegration,
+  widgetRenderer,
   fullFlow,
 ];

--- a/apps/notebook/src/content/index.ts
+++ b/apps/notebook/src/content/index.ts
@@ -2,7 +2,6 @@ import { introduction } from "./chapters/01-introduction";
 import { widgetRenderer } from "./chapters/02-agent-state";
 import { copilotKitIntegration } from "./chapters/03-generative-ui";
 import { deepAgent } from "./chapters/04-copilotkit-hooks";
-import { mcpSkills } from "./chapters/05-frontend-tools";
 import { fullFlow } from "./chapters/06-widget-renderer";
 import type { Chapter } from "@/lib/types";
 
@@ -11,6 +10,5 @@ export const chapters: Chapter[] = [
   widgetRenderer,
   copilotKitIntegration,
   deepAgent,
-  mcpSkills,
   fullFlow,
 ];

--- a/apps/notebook/src/content/index.ts
+++ b/apps/notebook/src/content/index.ts
@@ -1,0 +1,16 @@
+import { introduction } from "./chapters/01-introduction";
+import { agentState } from "./chapters/02-agent-state";
+import { generativeUi } from "./chapters/03-generative-ui";
+import { copilotKitHooks } from "./chapters/04-copilotkit-hooks";
+import { frontendTools } from "./chapters/05-frontend-tools";
+import { widgetRenderer } from "./chapters/06-widget-renderer";
+import type { Chapter } from "@/lib/types";
+
+export const chapters: Chapter[] = [
+  introduction,
+  agentState,
+  generativeUi,
+  copilotKitHooks,
+  frontendTools,
+  widgetRenderer,
+];

--- a/apps/notebook/src/content/index.ts
+++ b/apps/notebook/src/content/index.ts
@@ -1,16 +1,16 @@
 import { introduction } from "./chapters/01-introduction";
-import { agentState } from "./chapters/02-agent-state";
-import { generativeUi } from "./chapters/03-generative-ui";
-import { copilotKitHooks } from "./chapters/04-copilotkit-hooks";
-import { frontendTools } from "./chapters/05-frontend-tools";
-import { widgetRenderer } from "./chapters/06-widget-renderer";
+import { widgetRenderer } from "./chapters/02-agent-state";
+import { copilotKitIntegration } from "./chapters/03-generative-ui";
+import { deepAgent } from "./chapters/04-copilotkit-hooks";
+import { mcpSkills } from "./chapters/05-frontend-tools";
+import { fullFlow } from "./chapters/06-widget-renderer";
 import type { Chapter } from "@/lib/types";
 
 export const chapters: Chapter[] = [
   introduction,
-  agentState,
-  generativeUi,
-  copilotKitHooks,
-  frontendTools,
   widgetRenderer,
+  copilotKitIntegration,
+  deepAgent,
+  mcpSkills,
+  fullFlow,
 ];

--- a/apps/notebook/src/hooks/use-theme.tsx
+++ b/apps/notebook/src/hooks/use-theme.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { createContext, useContext, useEffect, useState } from "react";
+
+type Theme = "dark" | "light" | "system";
+
+const ThemeContext = createContext<{ theme: Theme; setTheme: (t: Theme) => void }>({
+  theme: "system",
+  setTheme: () => {},
+});
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setTheme] = useState<Theme>("system");
+
+  useEffect(() => {
+    const root = document.documentElement;
+    root.classList.remove("light", "dark");
+
+    if (theme === "system") {
+      const mq = window.matchMedia("(prefers-color-scheme: dark)");
+      const apply = () => {
+        root.classList.remove("light", "dark");
+        root.classList.add(mq.matches ? "dark" : "light");
+      };
+      apply();
+      mq.addEventListener("change", apply);
+      return () => mq.removeEventListener("change", apply);
+    }
+
+    root.classList.add(theme);
+  }, [theme]);
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export const useTheme = () => useContext(ThemeContext);

--- a/apps/notebook/src/lib/highlight.ts
+++ b/apps/notebook/src/lib/highlight.ts
@@ -1,0 +1,13 @@
+import { createHighlighter, type Highlighter } from "shiki";
+
+let highlighterPromise: Promise<Highlighter> | null = null;
+
+export function getHighlighter(): Promise<Highlighter> {
+  if (!highlighterPromise) {
+    highlighterPromise = createHighlighter({
+      themes: ["github-light", "github-dark"],
+      langs: ["typescript", "tsx", "javascript", "jsx", "python", "bash", "json", "yaml", "css", "html"],
+    });
+  }
+  return highlighterPromise;
+}

--- a/apps/notebook/src/lib/types.ts
+++ b/apps/notebook/src/lib/types.ts
@@ -1,0 +1,32 @@
+export type MarkdownCell = {
+  type: "markdown";
+  id: string;
+  content: string;
+};
+
+export type CodeCell = {
+  type: "code";
+  id: string;
+  language: string;
+  content: string;
+  filename?: string;
+};
+
+export type PlaygroundCell = {
+  type: "playground";
+  id: string;
+  files: Record<string, string>;
+  dependencies?: Record<string, string>;
+  activeFile?: string;
+  title?: string;
+};
+
+export type Cell = MarkdownCell | CodeCell | PlaygroundCell;
+
+export type Chapter = {
+  id: string;
+  title: string;
+  description: string;
+  icon: string;
+  cells: Cell[];
+};

--- a/apps/notebook/src/lib/types.ts
+++ b/apps/notebook/src/lib/types.ts
@@ -21,7 +21,14 @@ export type PlaygroundCell = {
   title?: string;
 };
 
-export type Cell = MarkdownCell | CodeCell | PlaygroundCell;
+export type MermaidCell = {
+  type: "mermaid";
+  id: string;
+  content: string;
+  title?: string;
+};
+
+export type Cell = MarkdownCell | CodeCell | PlaygroundCell | MermaidCell;
 
 export type Chapter = {
   id: string;

--- a/apps/notebook/tsconfig.json
+++ b/apps/notebook/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": ["node_modules"]
+}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dev:app": "turbo run dev --filter='@repo/app'",
     "dev:agent": "cd apps/agent && uv sync && uv run uvicorn main:app --host 0.0.0.0 --port 8123 --reload",
     "dev:mcp": "turbo run dev --filter='open-generative-ui-mcp'",
+    "dev:notebook": "turbo run dev --filter='@repo/notebook'",
     "build": "turbo run build",
     "lint": "turbo run lint",
     "clean": "turbo run clean"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,6 +116,58 @@ importers:
         specifier: ^5
         version: 5.9.3
 
+  apps/notebook:
+    dependencies:
+      '@codesandbox/sandpack-react':
+        specifier: ^2.19.0
+        version: 2.20.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next:
+        specifier: 16.1.6
+        version: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react:
+        specifier: ^19.2.4
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.2.4
+        version: 19.2.4(react@19.2.4)
+      react-markdown:
+        specifier: ^9.0.3
+        version: 9.1.0(@types/react@19.2.10)(react@19.2.4)
+      remark-gfm:
+        specifier: ^4.0.0
+        version: 4.0.1
+      shiki:
+        specifier: ^3.2.0
+        version: 3.22.0
+    devDependencies:
+      '@eslint/eslintrc':
+        specifier: ^3
+        version: 3.3.3
+      '@tailwindcss/postcss':
+        specifier: ^4
+        version: 4.1.18
+      '@types/node':
+        specifier: ^20
+        version: 20.19.31
+      '@types/react':
+        specifier: ^19
+        version: 19.2.10
+      '@types/react-dom':
+        specifier: ^19
+        version: 19.2.3(@types/react@19.2.10)
+      eslint:
+        specifier: ^9
+        version: 9.39.2(jiti@2.6.1)
+      eslint-config-next:
+        specifier: 16.1.6
+        version: 16.1.6(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      tailwindcss:
+        specifier: ^4
+        version: 4.1.18
+      typescript:
+        specifier: ^5
+        version: 5.9.3
+
 packages:
 
   '@0no-co/graphql.web@1.2.0':
@@ -305,6 +357,45 @@ packages:
 
   '@chevrotain/utils@11.0.3':
     resolution: {integrity: sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ==}
+
+  '@codemirror/autocomplete@6.20.1':
+    resolution: {integrity: sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A==}
+
+  '@codemirror/commands@6.10.3':
+    resolution: {integrity: sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==}
+
+  '@codemirror/lang-css@6.3.1':
+    resolution: {integrity: sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==}
+
+  '@codemirror/lang-html@6.4.11':
+    resolution: {integrity: sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw==}
+
+  '@codemirror/lang-javascript@6.2.5':
+    resolution: {integrity: sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==}
+
+  '@codemirror/language@6.12.3':
+    resolution: {integrity: sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==}
+
+  '@codemirror/lint@6.9.5':
+    resolution: {integrity: sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA==}
+
+  '@codemirror/state@6.6.0':
+    resolution: {integrity: sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==}
+
+  '@codemirror/view@6.41.0':
+    resolution: {integrity: sha512-6H/qadXsVuDY219Yljhohglve8xf4B8xJkVOEWfA5uiYKiTFppjqsvsfR5iPA0RbvRBoOyTZpbLIxe9+0UR8xA==}
+
+  '@codesandbox/nodebox@0.1.8':
+    resolution: {integrity: sha512-2VRS6JDSk+M+pg56GA6CryyUSGPjBEe8Pnae0QL3jJF1mJZJVMDKr93gJRtBbLkfZN6LD/DwMtf+2L0bpWrjqg==}
+
+  '@codesandbox/sandpack-client@2.19.8':
+    resolution: {integrity: sha512-CMV4nr1zgKzVpx4I3FYvGRM5YT0VaQhALMW9vy4wZRhEyWAtJITQIqZzrTGWqB1JvV7V72dVEUCUPLfYz5hgJQ==}
+
+  '@codesandbox/sandpack-react@2.20.0':
+    resolution: {integrity: sha512-takd1YpW/PMQ6KPQfvseWLHWklJovGY8QYj8MtWnskGKbjOGJ6uZfyZbcJ6aCFLQMpNyjTqz9AKNbvhCOZ1TUQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
+      react-dom: ^16.8.0 || ^17 || ^18 || ^19
 
   '@copilotkit/a2ui-renderer@1.54.0-next.6':
     resolution: {integrity: sha512-zDdKieiCJXnRstdkcIXpw7rjpJxUXSuGDhwFsCfetcL17pSv+Dbon18rK8Qdku8v6FCCxouUlkunh6iHcSzc9Q==}
@@ -909,6 +1000,24 @@ packages:
       react-dom:
         optional: true
 
+  '@lezer/common@1.5.1':
+    resolution: {integrity: sha512-6YRVG9vBkaY7p1IVxL4s44n5nUnaNnGM2/AckNgYOnxTG2kWh1vR8BMxPseWPjRNpb5VtXnMpeYAEAADoRV1Iw==}
+
+  '@lezer/css@1.3.3':
+    resolution: {integrity: sha512-RzBo8r+/6QJeow7aPHIpGVIH59xTcJXp399820gZoMo9noQDRVpJLheIBUicYwKcsbOYoBRoLZlf2720dG/4Tg==}
+
+  '@lezer/highlight@1.2.3':
+    resolution: {integrity: sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==}
+
+  '@lezer/html@1.3.13':
+    resolution: {integrity: sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==}
+
+  '@lezer/javascript@1.5.4':
+    resolution: {integrity: sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==}
+
+  '@lezer/lr@1.4.8':
+    resolution: {integrity: sha512-bPWa0Pgx69ylNlMlPvBPryqeLYQjyJjqPx+Aupm5zydLIF3NE+6MMLT8Yi23Bd9cif9VS00aUebn+6fDIGBcDA==}
+
   '@lit-labs/react@2.1.3':
     resolution: {integrity: sha512-OD9h2JynerBQUMNzb563jiVpxfvPF0HjQkKY2mx0lpVYvD7F+rtJpOGz6ek+6ufMidV3i+MPT9SX62OKWHFrQg==}
 
@@ -936,6 +1045,9 @@ packages:
   '@lukeed/uuid@2.0.1':
     resolution: {integrity: sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w==}
     engines: {node: '>=8'}
+
+  '@marijn/find-cluster-break@1.0.2':
+    resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
 
   '@mermaid-js/parser@0.6.3':
     resolution: {integrity: sha512-lnjOhe7zyHjc+If7yT4zoedx2vo4sHaTmtkl1+or8BRTnCtDmcTpAjpzDSfCZrshM5bCoz0GyidzadJAH1xobA==}
@@ -1022,6 +1134,9 @@ packages:
   '@nolyfill/is-core-module@1.0.39':
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
+
+  '@open-draft/deferred-promise@2.2.0':
+    resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
 
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
@@ -1359,6 +1474,16 @@ packages:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
+  '@react-hook/intersection-observer@3.1.2':
+    resolution: {integrity: sha512-mWU3BMkmmzyYMSuhO9wu3eJVP21N8TcgYm9bZnTrMwuM818bEk+0NRM3hP+c/TqA9Ln5C7qE53p1H0QMtzYdvQ==}
+    peerDependencies:
+      react: '>=16.8'
+
+  '@react-hook/passive-layout-effect@1.2.1':
+    resolution: {integrity: sha512-IwEphTD75liO8g+6taS+4oqz+nnroocNfWVHWz7j+N+ZO2vYrc6PV1q7GQhuahL0IOR7JccFTsFKQ/mb6iZWAg==}
+    peerDependencies:
+      react: '>=16.8'
+
   '@react-stately/flags@3.1.2':
     resolution: {integrity: sha512-2HjFcZx1MyQXoPqcBGALwWWmgFVUk2TuKVIQxCbRq7fPyWXIl6VHcakCLurdtYC2Iks7zizvz0Idv48MQ38DWg==}
 
@@ -1428,6 +1553,9 @@ packages:
 
   '@standard-schema/utils@0.3.0':
     resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
+
+  '@stitches/core@1.2.8':
+    resolution: {integrity: sha512-Gfkvwk9o9kE9r9XNBmJRfV8zONvXThnm1tcuojL04Uy5uRyqg93DC83lDebl0rocZCfKSjUv+fWYtMQmEDJldg==}
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -1942,6 +2070,9 @@ packages:
   ajv@8.17.1:
     resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
 
+  anser@2.3.5:
+    resolution: {integrity: sha512-vcZjxvvVoxTeR5XBNJB38oTu/7eDCZlwdz32N1eNgpyPF7j/Z7Idf+CUwQOkKKpJ7RJyjxgLHCM7vdIK0iCNMQ==}
+
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -2137,6 +2268,9 @@ packages:
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
 
+  clean-set@1.1.2:
+    resolution: {integrity: sha512-cA8uCj0qSoG9e0kevyOWXwPaELRPVg5Pxp6WskLMwerx257Zfnh8Nl0JBH59d7wQzij2CK7qEfJQK3RjuKKIug==}
+
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
@@ -2235,6 +2369,9 @@ packages:
 
   cose-base@2.2.0:
     resolution: {integrity: sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==}
+
+  crelt@1.0.6:
+    resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
 
   cross-inspect@1.0.1:
     resolution: {integrity: sha512-Pcw1JTvZLSJH83iiGWt6fRcT+BjZlCDRVwYLbUcHzv/CRpB7r0MlSrGbIyQvVSNyGnbt7G4AXuyCiDR3POvZ1A==}
@@ -2400,6 +2537,10 @@ packages:
     resolution: {integrity: sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==}
     engines: {node: '>=12'}
 
+  d@1.0.2:
+    resolution: {integrity: sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==}
+    engines: {node: '>=0.12'}
+
   dagre-d3-es@7.0.13:
     resolution: {integrity: sha512-efEhnxpSuwpYOKRm/L5KbqoZmNNukHa/Flty4Wp62JRvgH2ojwVgPgdYyr4twpieZnyRDdIH7PY2mopX26+j2Q==}
 
@@ -2510,6 +2651,10 @@ packages:
   dompurify@3.3.1:
     resolution: {integrity: sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==}
 
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
+
   dset@3.1.4:
     resolution: {integrity: sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==}
     engines: {node: '>=4'}
@@ -2584,6 +2729,17 @@ packages:
   es-toolkit@1.44.0:
     resolution: {integrity: sha512-6penXeZalaV88MM3cGkFZZfOoLGWshWWfdy0tWw/RlVVyhvMaWSBTOvXNeiW3e5FwdS5ePW0LGEu17zT139ktg==}
 
+  es5-ext@0.10.64:
+    resolution: {integrity: sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==}
+    engines: {node: '>=0.10'}
+
+  es6-iterator@2.0.3:
+    resolution: {integrity: sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==}
+
+  es6-symbol@3.1.4:
+    resolution: {integrity: sha512-U9bFFjX8tFiATgtkJ1zg25+KviIXpgRvRHS8sau3GfhVzThRQrOeksPeT0BWW2MNZs1OEWJ1DPXOQMn0KKRkvg==}
+    engines: {node: '>=0.12'}
+
   esbuild@0.27.3:
     resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
     engines: {node: '>=18'}
@@ -2592,6 +2748,9 @@ packages:
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
+
+  escape-carriage@1.3.1:
+    resolution: {integrity: sha512-GwBr6yViW3ttx1kb7/Oh+gKQ1/TrhYwxKqVmg5gS+BK+Qe2KrOa/Vh7w3HPBvgGf0LfcDGoY9I6NHKoA5Hozhw==}
 
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
@@ -2700,6 +2859,10 @@ packages:
       jiti:
         optional: true
 
+  esniff@2.0.1:
+    resolution: {integrity: sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==}
+    engines: {node: '>=0.10'}
+
   espree@10.4.0:
     resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -2726,6 +2889,9 @@ packages:
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
+
+  event-emitter@0.3.5:
+    resolution: {integrity: sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==}
 
   event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
@@ -2762,6 +2928,9 @@ packages:
   express@5.2.1:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
+
+  ext@1.7.0:
+    resolution: {integrity: sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -3135,6 +3304,10 @@ packages:
   internmap@2.0.3:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
+
+  intersection-observer@0.10.0:
+    resolution: {integrity: sha512-fn4bQ0Xq8FTej09YC/jqKZwtijpvARlRp6wxL5WTA6yPe2YWSJ5RJh7Nm79rK2qB0wr6iDQzH60XGq5V/7u8YQ==}
+    deprecated: The Intersection Observer polyfill is no longer needed and can safely be removed. Intersection Observer has been Baseline since 2019.
 
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -3539,6 +3712,10 @@ packages:
   lucide@0.525.0:
     resolution: {integrity: sha512-sfehWlaE/7NVkcEQ4T9JD3eID8RNMIGJBBUq9wF3UFiJIrcMKRbU3g1KGfDk4svcW7yw8BtDLXaXo02scDtUYQ==}
 
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -3904,6 +4081,9 @@ packages:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
+  next-tick@1.1.0:
+    resolution: {integrity: sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==}
+
   next@16.1.6:
     resolution: {integrity: sha512-hkyRkcu5x/41KoqnROkfTm2pZVbKxvbZRuNvKXLRXxs3VfyO0WhY50TQS40EuKO9SW3rBj/sF3WbVwDACeMZyw==}
     engines: {node: '>=20.9.0'}
@@ -4006,6 +4186,9 @@ packages:
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
+
+  outvariant@1.4.0:
+    resolution: {integrity: sha512-AlWY719RF02ujitly7Kk/0QlV+pXGFDHrHf9O2OKqyqgBieaPOIeuSkL8sRK6j2WK+/ZAURq2kZsY0d8JapUiw==}
 
   own-keys@1.0.1:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
@@ -4225,6 +4408,9 @@ packages:
       react: ^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  react-devtools-inline@4.4.0:
+    resolution: {integrity: sha512-ES0GolSrKO8wsKbsEkVeiR/ZAaHQTY4zDh1UW8DImVmm8oaGLl3ijJDvSGe+qDRKPZdPRnDtWWnSvvrgxXdThQ==}
+
   react-dom@19.2.4:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
     peerDependencies:
@@ -4238,6 +4424,9 @@ packages:
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
@@ -4253,6 +4442,12 @@ packages:
     peerDependencies:
       '@types/react': '>=16'
       react: '>=16'
+
+  react-markdown@9.1.0:
+    resolution: {integrity: sha512-xaijuJB0kzGiUdG7nc2MOMDUDBWPyGAjZtUrow9XxUeua8IqeP+VlIfAZ3bphpcLTnSZXz6z9jcVC/TCwbfgdw==}
+    peerDependencies:
+      '@types/react': '>=18'
+      react: '>=18'
 
   react-redux@9.2.0:
     resolution: {integrity: sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==}
@@ -4614,6 +4809,9 @@ packages:
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
 
+  static-browser-server@1.0.3:
+    resolution: {integrity: sha512-ZUyfgGDdFRbZGGJQ1YhiM930Yczz5VlbJObrQLlk24+qNHVQx4OlLcYswEUo3bIyNAbQUIUR9Yr5/Hqjzqb4zA==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
@@ -4626,6 +4824,9 @@ packages:
     resolution: {integrity: sha512-Y38fwRx5kCKTluwM+Gf27jbbi9q6Qy+WC9YrC1YbCpMkktT3PsRBJHMWiqYeF8y/JzLpB1IzDoeaB6qkQEDnAA==}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
+
+  strict-event-emitter@0.4.6:
+    resolution: {integrity: sha512-12KWeb+wixJohmnwNFerbyiBrAlq5qJLwIt38etRtKtmmHyDSoGlIqFE9wx+4IwG0aDjI7GV8tc8ZccjWZZtTg==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -4671,6 +4872,9 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  style-mod@4.1.3:
+    resolution: {integrity: sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==}
 
   style-to-js@1.1.21:
     resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
@@ -4847,6 +5051,9 @@ packages:
   type-is@2.0.1:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
+
+  type@2.7.3:
+    resolution: {integrity: sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==}
 
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
@@ -5065,6 +5272,9 @@ packages:
 
   vscode-uri@3.0.8:
     resolution: {integrity: sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==}
+
+  w3c-keyname@2.2.8:
+    resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
 
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
@@ -5428,6 +5638,114 @@ snapshots:
   '@chevrotain/types@11.0.3': {}
 
   '@chevrotain/utils@11.0.3': {}
+
+  '@codemirror/autocomplete@6.20.1':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.0
+      '@lezer/common': 1.5.1
+
+  '@codemirror/commands@6.10.3':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.0
+      '@lezer/common': 1.5.1
+
+  '@codemirror/lang-css@6.3.1':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@lezer/common': 1.5.1
+      '@lezer/css': 1.3.3
+
+  '@codemirror/lang-html@6.4.11':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/lang-css': 6.3.1
+      '@codemirror/lang-javascript': 6.2.5
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.0
+      '@lezer/common': 1.5.1
+      '@lezer/css': 1.3.3
+      '@lezer/html': 1.3.13
+
+  '@codemirror/lang-javascript@6.2.5':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/language': 6.12.3
+      '@codemirror/lint': 6.9.5
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.0
+      '@lezer/common': 1.5.1
+      '@lezer/javascript': 1.5.4
+
+  '@codemirror/language@6.12.3':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.0
+      '@lezer/common': 1.5.1
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.8
+      style-mod: 4.1.3
+
+  '@codemirror/lint@6.9.5':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.0
+      crelt: 1.0.6
+
+  '@codemirror/state@6.6.0':
+    dependencies:
+      '@marijn/find-cluster-break': 1.0.2
+
+  '@codemirror/view@6.41.0':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      crelt: 1.0.6
+      style-mod: 4.1.3
+      w3c-keyname: 2.2.8
+
+  '@codesandbox/nodebox@0.1.8':
+    dependencies:
+      outvariant: 1.4.0
+      strict-event-emitter: 0.4.6
+
+  '@codesandbox/sandpack-client@2.19.8':
+    dependencies:
+      '@codesandbox/nodebox': 0.1.8
+      buffer: 6.0.3
+      dequal: 2.0.3
+      mime-db: 1.54.0
+      outvariant: 1.4.0
+      static-browser-server: 1.0.3
+
+  '@codesandbox/sandpack-react@2.20.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/commands': 6.10.3
+      '@codemirror/lang-css': 6.3.1
+      '@codemirror/lang-html': 6.4.11
+      '@codemirror/lang-javascript': 6.2.5
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.0
+      '@codesandbox/sandpack-client': 2.19.8
+      '@lezer/highlight': 1.2.3
+      '@react-hook/intersection-observer': 3.1.2(react@19.2.4)
+      '@stitches/core': 1.2.8
+      anser: 2.3.5
+      clean-set: 1.1.2
+      dequal: 2.0.3
+      escape-carriage: 1.3.1
+      lz-string: 1.5.0
+      react: 19.2.4
+      react-devtools-inline: 4.4.0
+      react-dom: 19.2.4(react@19.2.4)
+      react-is: 17.0.2
 
   '@copilotkit/a2ui-renderer@1.54.0-next.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(signal-polyfill@0.2.2)':
     dependencies:
@@ -6098,6 +6416,34 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
     optional: true
 
+  '@lezer/common@1.5.1': {}
+
+  '@lezer/css@1.3.3':
+    dependencies:
+      '@lezer/common': 1.5.1
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.8
+
+  '@lezer/highlight@1.2.3':
+    dependencies:
+      '@lezer/common': 1.5.1
+
+  '@lezer/html@1.3.13':
+    dependencies:
+      '@lezer/common': 1.5.1
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.8
+
+  '@lezer/javascript@1.5.4':
+    dependencies:
+      '@lezer/common': 1.5.1
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.8
+
+  '@lezer/lr@1.4.8':
+    dependencies:
+      '@lezer/common': 1.5.1
+
   '@lit-labs/react@2.1.3(@types/react@19.2.10)':
     dependencies:
       '@lit/react': 1.0.8(@types/react@19.2.10)
@@ -6128,6 +6474,8 @@ snapshots:
   '@lukeed/uuid@2.0.1':
     dependencies:
       '@lukeed/csprng': 1.1.0
+
+  '@marijn/find-cluster-break@1.0.2': {}
 
   '@mermaid-js/parser@0.6.3':
     dependencies:
@@ -6207,6 +6555,8 @@ snapshots:
       fastq: 1.20.1
 
   '@nolyfill/is-core-module@1.0.39': {}
+
+  '@open-draft/deferred-promise@2.2.0': {}
 
   '@opentelemetry/api@1.9.0': {}
 
@@ -6526,6 +6876,16 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
+  '@react-hook/intersection-observer@3.1.2(react@19.2.4)':
+    dependencies:
+      '@react-hook/passive-layout-effect': 1.2.1(react@19.2.4)
+      intersection-observer: 0.10.0
+      react: 19.2.4
+
+  '@react-hook/passive-layout-effect@1.2.1(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+
   '@react-stately/flags@3.1.2':
     dependencies:
       '@swc/helpers': 0.5.18
@@ -6616,6 +6976,8 @@ snapshots:
   '@standard-schema/spec@1.1.0': {}
 
   '@standard-schema/utils@0.3.0': {}
+
+  '@stitches/core@1.2.8': {}
 
   '@swc/helpers@0.5.15':
     dependencies:
@@ -7143,6 +7505,8 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
+  anser@2.3.5: {}
+
   ansi-regex@5.0.1: {}
 
   ansi-styles@4.3.0:
@@ -7381,6 +7745,8 @@ snapshots:
     dependencies:
       clsx: 2.1.1
 
+  clean-set@1.1.2: {}
+
   client-only@0.0.1: {}
 
   cliui@8.0.1:
@@ -7464,6 +7830,8 @@ snapshots:
   cose-base@2.2.0:
     dependencies:
       layout-base: 2.0.1
+
+  crelt@1.0.6: {}
 
   cross-inspect@1.0.1:
     dependencies:
@@ -7656,6 +8024,11 @@ snapshots:
       d3-transition: 3.0.1(d3-selection@3.0.0)
       d3-zoom: 3.0.0
 
+  d@1.0.2:
+    dependencies:
+      es5-ext: 0.10.64
+      type: 2.7.3
+
   dagre-d3-es@7.0.13:
     dependencies:
       d3: 7.9.0
@@ -7748,6 +8121,8 @@ snapshots:
   dompurify@3.3.1:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
+
+  dotenv@16.6.1: {}
 
   dset@3.1.4: {}
 
@@ -7883,6 +8258,24 @@ snapshots:
 
   es-toolkit@1.44.0: {}
 
+  es5-ext@0.10.64:
+    dependencies:
+      es6-iterator: 2.0.3
+      es6-symbol: 3.1.4
+      esniff: 2.0.1
+      next-tick: 1.1.0
+
+  es6-iterator@2.0.3:
+    dependencies:
+      d: 1.0.2
+      es5-ext: 0.10.64
+      es6-symbol: 3.1.4
+
+  es6-symbol@3.1.4:
+    dependencies:
+      d: 1.0.2
+      ext: 1.7.0
+
   esbuild@0.27.3:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.27.3
@@ -7914,6 +8307,8 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  escape-carriage@1.3.1: {}
+
   escape-html@1.0.3: {}
 
   escape-string-regexp@4.0.0: {}
@@ -7927,6 +8322,26 @@ snapshots:
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-react-hooks: 7.0.1(eslint@9.39.2(jiti@2.6.1))
+      globals: 16.4.0
+      typescript-eslint: 8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@typescript-eslint/parser'
+      - eslint-import-resolver-webpack
+      - eslint-plugin-import-x
+      - supports-color
+
+  eslint-config-next@16.1.6(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3):
+    dependencies:
+      '@next/eslint-plugin-next': 16.1.6
+      eslint: 9.39.2(jiti@2.6.1)
+      eslint-import-resolver-node: 0.3.9
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.2(jiti@2.6.1))
@@ -7998,6 +8413,33 @@ snapshots:
       tsconfig-paths: 3.15.0
     optionalDependencies:
       '@typescript-eslint/parser': 8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
+    dependencies:
+      '@rtsao/scc': 1.1.0
+      array-includes: 3.1.9
+      array.prototype.findlastindex: 1.2.6
+      array.prototype.flat: 1.3.3
+      array.prototype.flatmap: 1.3.3
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint: 9.39.2(jiti@2.6.1)
+      eslint-import-resolver-node: 0.3.9
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      hasown: 2.0.2
+      is-core-module: 2.16.1
+      is-glob: 4.0.3
+      minimatch: 3.1.2
+      object.fromentries: 2.0.8
+      object.groupby: 1.0.3
+      object.values: 1.2.1
+      semver: 6.3.1
+      string.prototype.trimend: 1.0.9
+      tsconfig-paths: 3.15.0
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -8105,6 +8547,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  esniff@2.0.1:
+    dependencies:
+      d: 1.0.2
+      es5-ext: 0.10.64
+      event-emitter: 0.3.5
+      type: 2.7.3
+
   espree@10.4.0:
     dependencies:
       acorn: 8.15.0
@@ -8126,6 +8575,11 @@ snapshots:
   esutils@2.0.3: {}
 
   etag@1.8.1: {}
+
+  event-emitter@0.3.5:
+    dependencies:
+      d: 1.0.2
+      es5-ext: 0.10.64
 
   event-target-shim@5.0.1: {}
 
@@ -8213,6 +8667,10 @@ snapshots:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
+
+  ext@1.7.0:
+    dependencies:
+      type: 2.7.3
 
   extend@3.0.2: {}
 
@@ -8662,6 +9120,8 @@ snapshots:
 
   internmap@2.0.3: {}
 
+  intersection-observer@0.10.0: {}
+
   ipaddr.js@1.9.1: {}
 
   is-alphabetical@1.0.4: {}
@@ -9023,6 +9483,8 @@ snapshots:
       react: 19.2.4
 
   lucide@0.525.0: {}
+
+  lz-string@1.5.0: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -9705,6 +10167,8 @@ snapshots:
 
   negotiator@1.0.0: {}
 
+  next-tick@1.1.0: {}
+
   next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@next/env': 16.1.6
@@ -9821,6 +10285,8 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
       word-wrap: 1.2.5
+
+  outvariant@1.4.0: {}
 
   own-keys@1.0.1:
     dependencies:
@@ -10058,6 +10524,10 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
+  react-devtools-inline@4.4.0:
+    dependencies:
+      es6-symbol: 3.1.4
+
   react-dom@19.2.4(react@19.2.4):
     dependencies:
       react: 19.2.4
@@ -10071,6 +10541,8 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
 
   react-is@16.13.1: {}
+
+  react-is@17.0.2: {}
 
   react-is@18.3.1: {}
 
@@ -10111,6 +10583,24 @@ snapshots:
       unified: 10.1.2
       unist-util-visit: 4.1.2
       vfile: 5.3.7
+    transitivePeerDependencies:
+      - supports-color
+
+  react-markdown@9.1.0(@types/react@19.2.10)(react@19.2.4):
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/react': 19.2.10
+      devlop: 1.1.0
+      hast-util-to-jsx-runtime: 2.3.6
+      html-url-attributes: 3.0.1
+      mdast-util-to-hast: 13.2.1
+      react: 19.2.4
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -10627,6 +11117,13 @@ snapshots:
 
   stable-hash@0.0.5: {}
 
+  static-browser-server@1.0.3:
+    dependencies:
+      '@open-draft/deferred-promise': 2.2.0
+      dotenv: 16.6.1
+      mime-db: 1.54.0
+      outvariant: 1.4.0
+
   statuses@2.0.2: {}
 
   stop-iteration-iterator@1.1.0:
@@ -10665,6 +11162,8 @@ snapshots:
       - micromark
       - micromark-util-types
       - supports-color
+
+  strict-event-emitter@0.4.6: {}
 
   string-width@4.2.3:
     dependencies:
@@ -10738,6 +11237,8 @@ snapshots:
   strip-bom@3.0.0: {}
 
   strip-json-comments@3.1.1: {}
+
+  style-mod@4.1.3: {}
 
   style-to-js@1.1.21:
     dependencies:
@@ -10889,6 +11390,8 @@ snapshots:
       content-type: 1.0.5
       media-typer: 1.1.0
       mime-types: 3.0.2
+
+  type@2.7.3: {}
 
   typed-array-buffer@1.0.3:
     dependencies:
@@ -11180,6 +11683,8 @@ snapshots:
       vscode-languageserver-protocol: 3.17.5
 
   vscode-uri@3.0.8: {}
+
+  w3c-keyname@2.2.8: {}
 
   web-namespaces@2.0.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,6 +121,9 @@ importers:
       '@codesandbox/sandpack-react':
         specifier: ^2.19.0
         version: 2.20.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      mermaid:
+        specifier: ^11.4.0
+        version: 11.12.2
       next:
         specifier: 16.1.6
         version: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -160,7 +163,7 @@ importers:
         version: 9.39.2(jiti@2.6.1)
       eslint-config-next:
         specifier: 16.1.6
-        version: 16.1.6(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+        version: 16.1.6(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       tailwindcss:
         specifier: ^4
         version: 4.1.18
@@ -8335,26 +8338,6 @@ snapshots:
       - eslint-plugin-import-x
       - supports-color
 
-  eslint-config-next@16.1.6(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3):
-    dependencies:
-      '@next/eslint-plugin-next': 16.1.6
-      eslint: 9.39.2(jiti@2.6.1)
-      eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-react-hooks: 7.0.1(eslint@9.39.2(jiti@2.6.1))
-      globals: 16.4.0
-      typescript-eslint: 8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - '@typescript-eslint/parser'
-      - eslint-import-resolver-webpack
-      - eslint-plugin-import-x
-      - supports-color
-
   eslint-import-resolver-node@0.3.9:
     dependencies:
       debug: 3.2.7
@@ -8413,33 +8396,6 @@ snapshots:
       tsconfig-paths: 3.15.0
     optionalDependencies:
       '@typescript-eslint/parser': 8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
-
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
-    dependencies:
-      '@rtsao/scc': 1.1.0
-      array-includes: 3.1.9
-      array.prototype.findlastindex: 1.2.6
-      array.prototype.flat: 1.3.3
-      array.prototype.flatmap: 1.3.3
-      debug: 3.2.7
-      doctrine: 2.1.0
-      eslint: 9.39.2(jiti@2.6.1)
-      eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
-      hasown: 2.0.2
-      is-core-module: 2.16.1
-      is-glob: 4.0.3
-      minimatch: 3.1.2
-      object.fromentries: 2.0.8
-      object.groupby: 1.0.3
-      object.values: 1.2.1
-      semver: 6.3.1
-      string.prototype.trimend: 1.0.9
-      tsconfig-paths: 3.15.0
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
   - "apps/app"
   - "apps/mcp"
+  - "apps/notebook"


### PR DESCRIPTION
## Summary
- Adds a standalone Next.js app (`apps/notebook`) that explains OpenGenerativeUI concepts in a Jupyter notebook-like format
- Three cell types: **markdown** (react-markdown), **code** (Shiki syntax highlighting), and **interactive playground** (Sandpack live editor + preview)
- 6 chapters covering: Introduction, Agent State, Generative UI, CopilotKit Hooks, Frontend Tools, and Widget Renderer
- Uses the same brand design system (Plus Jakarta Sans, lilac/mint palette, glassmorphism) as the main app
- Runs on port 3001 via `pnpm dev:notebook`

## Test plan
- [ ] Run `pnpm dev:notebook` and verify it starts on port 3001
- [ ] Navigate through all 6 chapters via sidebar
- [ ] Verify code cells show syntax highlighting with copy button
- [ ] Edit code in playground cells and confirm live preview updates
- [ ] Test dark mode toggle works across all cell types
- [ ] Test mobile responsive layout (sidebar collapses to hamburger)
- [ ] Run `pnpm build --filter='@repo/notebook'` to verify production build

🤖 Generated with [Claude Code](https://claude.com/claude-code)