### PR TITLE
Harden CI: SHA-pin all actions, add persist-credentials: false

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: "0 0 * * *" # Run daily at midnight UTC
 
+permissions:
+  contents: read
+
 jobs:
   smoke:
     name: Smoke / ${{ matrix.os }} / Node ${{ matrix.node }}
@@ -20,15 +23,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ matrix.node }}
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
       - name: Install dependencies (monorepo)
         run: pnpm install
@@ -107,15 +112,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
       - name: Install dependencies
         run: pnpm install
@@ -132,7 +139,7 @@ jobs:
       github.event_name == 'schedule'
     steps:
       - name: Notify Slack
-        uses: slackapi/slack-github-action@v2.1.0
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook


### PR DESCRIPTION
## Summary

- SHA-pin all GitHub Actions (`actions/checkout`, `actions/setup-node`,
  `pnpm/action-setup`, `slackapi/slack-github-action`) to immutable
  commit SHAs with version comments
- Add `persist-credentials: false` to all `actions/checkout` steps to
  prevent token leakage in a public repo
- Add top-level `permissions: contents: read` to enforce least-privilege
  on the workflow's GITHUB_TOKEN

## Why

Public repos are vulnerable to supply-chain attacks via tag-mutable
action references. SHA-pinning ensures the exact code that was audited
is what runs. Restricting token permissions and persistence limits blast
radius if a dependency is compromised.

## Test plan

- [ ] CI passes on this PR (smoke + lint on all matrix entries)
- [ ] Slack notification step still resolves correctly