### PR TITLE
Pin deployed agent model to gpt-5.4

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -23,8 +23,10 @@ services:
         sync: false
       - key: LANGSMITH_API_KEY
         sync: false
+      # gpt-* names route via OpenAI, Claude names via Anthropic
+      # (see apps/agent/src/model.py)
       - key: LLM_MODEL
-        value: claude-fable-5
+        value: gpt-5.4-2026-03-05
     buildFilter:
       paths:
         - apps/agent/**


### PR DESCRIPTION
Sets the Render agent service's `LLM_MODEL` to `gpt-5.4-2026-03-05`, using the provider routing from #85 (`gpt-*` names use the OpenAI client path). One-line blueprint change; the routing is covered by the existing pytest suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)